### PR TITLE
extend routes type definition and dynamic page layout headers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,61 +1,23 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { lazy, Suspense } from "react";
+import { useRoutes } from "react-router-dom";
+import { Suspense } from "react";
 
-import { RequireAuthRoute, RequireShopRoute, UnauthenticatedRoute } from "@components/Routes";
 import { AccountProvider } from "@containers/AccountProvider";
-import { AppLayout } from "@containers/Layouts";
 import { ShopProvider } from "@containers/ShopProvider";
 import { Loader } from "@components/Loader";
 
-import Dashboard from "./pages/Dashboard";
-import NotFound from "./pages/NotFound";
-import CreateShop from "./pages/CreateShop";
-import ShippingConfiguration from "./pages/Settings/ShippingAndFulfillment";
-
-const Login = lazy(() => import("./pages/Login"));
-const SignUp = lazy(() => import("./pages/SignUp"));
-const PasswordReset = lazy(() => import("./pages/PasswordReset"));
-const NewPassword = lazy(() => import("./pages/NewPassword"));
-const ShippingMethods = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Methods"));
-const ShippingSurcharges = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Surcharges"));
-const ShippingRestrictions = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Restrictions"));
+import { routes } from "./routes";
 
 function App() {
+  const routeElement = useRoutes(routes);
+
   return (
-    <BrowserRouter>
-      <Suspense fallback={<Loader />}>
-        <ShopProvider>
-          <AccountProvider>
-            <Routes>
-              <Route element={<UnauthenticatedRoute />}>
-                <Route path="/signup" element={<SignUp />} />
-                <Route path="/login" element={<Login />} />
-                <Route path="/password-reset/new" element={<PasswordReset />} />
-                <Route path="/password-reset" element={<NewPassword />} />
-              </Route>
-
-              <Route element={<RequireAuthRoute />}>
-                <Route path="/new-shop" element={<CreateShop />} />
-                <Route element={<RequireShopRoute />}>
-                  <Route path="/" element={<AppLayout />}>
-                    <Route index element={<Dashboard />} />
-                    <Route path="settings">
-                      <Route path="shipping-fulfillment" element={<ShippingConfiguration />}>
-                        <Route index element={<ShippingMethods/>} />
-                        <Route path="surcharges" element={<ShippingSurcharges />} />
-                        <Route path="restrictions" element={<ShippingRestrictions />} />
-                      </Route>
-                    </Route>
-                    <Route path="*" element={<NotFound />} />
-                  </Route>
-                </Route>
-              </Route>
-            </Routes>
-          </AccountProvider>
-        </ShopProvider>
-      </Suspense>
-
-    </BrowserRouter>
+    <Suspense fallback={<Loader />}>
+      <ShopProvider>
+        <AccountProvider>
+          {routeElement}
+        </AccountProvider>
+      </ShopProvider>
+    </Suspense>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
-import { useRoutes } from "react-router-dom";
+import { useRoutes as useReactRouterRoutes } from "react-router-dom";
 import { Suspense } from "react";
 
 import { AccountProvider } from "@containers/AccountProvider";
 import { ShopProvider } from "@containers/ShopProvider";
 import { Loader } from "@components/Loader";
-
-import { routes } from "./routes";
+import { useRoutes } from "@containers/RoutesProvider";
 
 function App() {
-  const routeElement = useRoutes(routes);
+  const routes = useRoutes();
+  const routeElement = useReactRouterRoutes(routes);
 
   return (
     <Suspense fallback={<Loader />}>

--- a/src/components/AppHeader/SubHeader.tsx
+++ b/src/components/AppHeader/SubHeader.tsx
@@ -6,7 +6,7 @@ import Paper from "@mui/material/Paper";
 
 export type SubHeaderItemProps = {
   label: string
-  href: string
+  path: string
   key: string
 }
 
@@ -23,12 +23,12 @@ const activeStyles: SxProps = {
 };
 
 
-const SubHeaderItem = ({ href, label }: SubHeaderItemProps) => {
-  const resolvedPath = useResolvedPath(href);
+const SubHeaderItem = ({ path, label }: SubHeaderItemProps) => {
+  const resolvedPath = useResolvedPath(path);
   const match = useMatch({ path: resolvedPath.pathname, end: true });
 
   return <Button size="small" color={match ? "success" : "secondary"} component={Link}
-    to={href} sx={match ? activeStyles : {}}>
+    to={path} sx={match ? activeStyles : {}}>
     {label}
   </Button>;
 };

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -3,11 +3,13 @@ import Drawer from "@mui/material/Drawer";
 
 import { SIDEBAR_WIDTH } from "../../constants";
 
-import { SidebarItems } from "./SidebarItems";
+import { SidebarFeaturesProps } from "./defaultSidebarItems";
+import { SidebarContent } from "./SidebarContent";
 
 type SidebarProps = {
   mobileOpen: boolean
   handleDrawerToggle: () => void
+  sidebar?: SidebarFeaturesProps
 }
 
 const sharedStyles = {
@@ -19,7 +21,7 @@ const sharedStyles = {
   pb: 1
 };
 
-export const Sidebar = ({ mobileOpen, handleDrawerToggle }: SidebarProps) => (
+export const Sidebar = ({ mobileOpen, handleDrawerToggle, sidebar }: SidebarProps) => (
   <Box component="nav" sx={{ width: { sm: SIDEBAR_WIDTH }, flexShrink: { sm: 0 } }}>
     <Drawer
       variant="temporary"
@@ -33,7 +35,7 @@ export const Sidebar = ({ mobileOpen, handleDrawerToggle }: SidebarProps) => (
         "& .MuiDrawer-paper": sharedStyles
       }}
     >
-      <SidebarItems />
+      <SidebarContent sidebar={sidebar}/>
     </Drawer>
     <Drawer
       variant="permanent"
@@ -43,7 +45,7 @@ export const Sidebar = ({ mobileOpen, handleDrawerToggle }: SidebarProps) => (
       }}
       open
     >
-      <SidebarItems />
+      <SidebarContent sidebar={sidebar}/>
     </Drawer>
   </Box>
 );

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1,0 +1,61 @@
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import Box from "@mui/material/Box";
+import SupportOutlinedIcon from "@mui/icons-material/SupportOutlined";
+import Typography from "@mui/material/Typography";
+import ListItem from "@mui/material/ListItem";
+import Link from "@mui/material/Link";
+
+import { SystemInformation } from "@components/SystemInformation";
+
+import { SidebarItem } from "./SidebarItem";
+import { ProfileToolbar } from "./ProfileToolbar";
+import { FEATURE_KEYS, SidebarFeaturesProps, SIDEBAR_ITEMS, STOREFRONT_FEATURES } from "./defaultSidebarItems";
+import { SidebarItems } from "./SidebarItems";
+
+
+type SidebarItemsProps = {
+  sidebar?: SidebarFeaturesProps
+}
+
+export const SidebarContent = ({ sidebar = SIDEBAR_ITEMS }: SidebarItemsProps) => {
+  const { coreFeatures, plugins = [] } = sidebar;
+
+  return (
+    <>
+      <ProfileToolbar />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "space-between"
+        }}
+      >
+        <Box>
+          <List>
+            {STOREFRONT_FEATURES.map(({ text, icon, to }) => (
+              <SidebarItem key={text} icon={icon} to={to} text={text} />
+            ))}
+          </List>
+          <Divider sx={{ mx: 2, borderColor: "background.darkGrey" }} />
+          {coreFeatures.length ? <SidebarItems items={[{ text: "Stores", key: FEATURE_KEYS.stores, subItems: coreFeatures }]}/> : null}
+          {plugins.length ? <SidebarItems items={plugins}/> : null}
+        </Box>
+        <List>
+          <SystemInformation />
+          <SidebarItem
+            key="documentation"
+            icon={<SupportOutlinedIcon fontSize="small" />}
+            onClick={() => window.open("https://mailchimp.com/developer/open-commerce/docs/", "_blank")}
+            text="Documentation"
+          />
+          <ListItem dense sx={{ py: 0.25, px: 0, justifyContent: "center", mt: 1 }}>
+            <Typography variant="body2">Powered by <Link underline="none" href="https://mailchimp.com/developer/open-commerce/" target="_blank" sx={{ fontSize: "inherit" }}>Open Commerce</Link></Typography>
+          </ListItem>
+
+        </List>
+      </Box>
+    </>
+  );
+};

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -7,7 +7,7 @@ import { NavLink, useMatch, useResolvedPath } from "react-router-dom";
 export type SidebarItemProps = {
   to?: string
   text: string
-  icon: JSX.Element
+  icon?: JSX.Element
   onClick?: () => void
 }
 
@@ -45,7 +45,7 @@ const NavLinkSidebarItem = ({ to, text, icon }: NavLinkSidebarItemProps) => {
       dense
       sx={sharedStyles}
     >
-      <ListItemIcon>{icon}</ListItemIcon>
+      {icon ? <ListItemIcon>{icon}</ListItemIcon> : null}
       <ListItemText primary={text} />
     </ListItemButton>
   );
@@ -61,7 +61,7 @@ export const SidebarItem = ({ to, onClick, ...props }: SidebarItemProps) => (
         sx={sharedStyles}
         onClick={onClick}
       >
-        <ListItemIcon>{props.icon}</ListItemIcon>
+        {props.icon ? <ListItemIcon>{props.icon}</ListItemIcon> : null}
         <ListItemText primary={props.text} />
       </ListItemButton>
     )}

--- a/src/components/Sidebar/SidebarItems.tsx
+++ b/src/components/Sidebar/SidebarItems.tsx
@@ -1,115 +1,11 @@
-import Divider from "@mui/material/Divider";
-import List from "@mui/material/List";
-import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
-import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
-import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
-import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
-import ContentPasteOutlinedIcon from "@mui/icons-material/ContentPasteOutlined";
-import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
-import LocalOfferOutlinedIcon from "@mui/icons-material/LocalOfferOutlined";
-import CategoryOutlinedIcon from "@mui/icons-material/CategoryOutlined";
-import Box from "@mui/material/Box";
-import SupportOutlinedIcon from "@mui/icons-material/SupportOutlined";
-import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
-import CreditCardOutlinedIcon from "@mui/icons-material/CreditCardOutlined";
-import ExposureOutlinedIcon from "@mui/icons-material/ExposureOutlined";
-import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
-import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
-import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
 import { useMemo } from "react";
-import ListItemButton from "@mui/material/ListItemButton";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import Typography from "@mui/material/Typography";
-import ListItem from "@mui/material/ListItem";
-import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
 
-import { SystemInformation } from "@components/SystemInformation";
-
-import { SidebarItem, SidebarItemProps } from "./SidebarItem";
-import { ProfileToolbar } from "./ProfileToolbar";
-
-type ItemProps = SidebarItemProps & {
-  subItems?: ItemProps[]
-  prev?: string
-}
-
-const ITEMS: SidebarItemProps[] = [
-  {
-    text: "Dashboard",
-    to: "/",
-    icon: <HomeOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "View Storefront",
-    to: "/storefront",
-    icon: <OpenInNewOutlinedIcon fontSize="small" />
-  }
-];
-
-const CORE_FEATURES: ItemProps[] = [
-  {
-    text: "Products",
-    to: "/products",
-    icon: <ContentPasteOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "Orders",
-    to: "/orders",
-    icon: <ReceiptLongOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "Customers",
-    to: "/customers",
-    icon: <GroupOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "Promotions",
-    to: "/promotions",
-    icon: <LocalOfferOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "Categories",
-    to: "/categories",
-    icon: <CategoryOutlinedIcon fontSize="small" />
-  },
-  {
-    text: "Settings",
-    icon: <SettingsOutlinedIcon fontSize="small" />,
-    prev: "/products",
-    subItems: [
-      {
-        text: "Users & Permissions",
-        icon: <GroupOutlinedIcon fontSize="small" />,
-        to: "/settings/users"
-      },
-      {
-        text: "Shop Details",
-        icon: <FactCheckOutlinedIcon fontSize="small" />,
-        to: "/settings/shop-details"
-      },
-      {
-        text: "Payments",
-        icon: <CreditCardOutlinedIcon fontSize="small" />,
-        to: "/settings/payments"
-      },
-      {
-        text: "Taxes",
-        icon: <ExposureOutlinedIcon fontSize="small" />,
-        to: "/settings/taxes"
-      },
-      {
-        text: "Shipping & Fulfillment",
-        icon: <LocalShippingOutlinedIcon fontSize="small" />,
-        to: "/settings/shipping-fulfillment"
-      },
-      {
-        text: "Transactional Emails",
-        icon: <EmailOutlinedIcon fontSize="small" />,
-        to: "/settings/emails"
-      }
-    ]
-  }
-];
+import { ItemProps } from "./defaultSidebarItems";
+import { SidebarItem } from "./SidebarItem";
 
 function findActiveItems(items: ItemProps[], pathName: string, path: ItemProps[] = []): ItemProps[] {
   if (!items.length) return [];
@@ -125,94 +21,55 @@ function findActiveItems(items: ItemProps[], pathName: string, path: ItemProps[]
   return [];
 }
 
-type State = {
+
+type SidebarItemsProps = {
   items: ItemProps[]
-  title: string
-  prev?: string
 }
 
-const defaultState: State = {
-  title: "Store",
-  items: CORE_FEATURES
-};
-
-export const SidebarItems = () => {
+export const SidebarItems = ({ items }:SidebarItemsProps) => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const activeMenuItem = useMemo(() => {
-    const items = findActiveItems(CORE_FEATURES, location.pathname);
-    const parent = items.length <= 1 ? null : items[items.length - 2];
-    return parent ? { title: parent.text, items: parent.subItems ?? [], prev: parent.prev } : defaultState;
-  }, [location.pathname]);
+  const activeMenuItem: ItemProps = useMemo(() => {
+    const activeItems = findActiveItems(items, location.pathname);
+    const parent = activeItems.length <= 1 ? null : activeItems[activeItems.length - 2];
+    return parent ?? items[0];
+  }, [items, location.pathname]);
 
   return (
-    <>
-      <ProfileToolbar />
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          flex: 1,
-          justifyContent: "space-between"
-        }}
-      >
-        <Box>
-          <List>
-            {ITEMS.map(({ text, icon, to }) => (
-              <SidebarItem key={text} icon={icon} to={to} text={text} />
-            ))}
-          </List>
-          <Divider sx={{ mx: 2, borderColor: "background.darkGrey" }} />
-          <List
-            subheader={
-              <ListItemButton
-                sx={{
-                  "bgcolor": "background.dark",
-                  "color": "grey.500",
-                  "textTransform": "uppercase",
-                  "display": "flex",
-                  "alignItems": "center",
-                  "mt": 1,
-                  "fontSize": 12,
-                  "fontWeight": 700,
-                  "&.Mui-disabled": {
-                    color: "grey.500",
-                    opacity: 1
-                  }
-                }}
-                disableRipple
-                disabled={!activeMenuItem.prev}
-                component={NavLink}
-                to={activeMenuItem.prev ?? "/"}
-              >
-                {activeMenuItem.prev && <KeyboardArrowLeftIcon sx={{ fontSize: "1rem" }} />} {activeMenuItem.title}
-              </ListItemButton>
+    <List
+      subheader={
+        <ListItemButton
+          sx={{
+            "bgcolor": "background.dark",
+            "color": "grey.500",
+            "textTransform": "uppercase",
+            "display": "flex",
+            "alignItems": "center",
+            "mt": 1,
+            "fontSize": 12,
+            "fontWeight": 700,
+            "&.Mui-disabled": {
+              color: "grey.500",
+              opacity: 1
             }
-          >
-            {activeMenuItem.items.map((item) => (
-              <SidebarItem
-                key={item.text}
-                onClick={() => navigate(item.subItems?.[0].to ?? "/")}
-                {...item}
-              />
-            ))}
-          </List>
-        </Box>
-        <List>
-          <SystemInformation />
-          <SidebarItem
-            key="documentation"
-            icon={<SupportOutlinedIcon fontSize="small" />}
-            onClick={() => window.open("https://mailchimp.com/developer/open-commerce/docs/", "_blank")}
-            text="Documentation"
-          />
-          <ListItem dense sx={{ py: 0.25, px: 0, justifyContent: "center", mt: 1 }}>
-            <Typography variant="body2">Powered by <Link underline="none" href="https://mailchimp.com/developer/open-commerce/" target="_blank" sx={{ fontSize: "inherit" }}>Open Commerce</Link></Typography>
-          </ListItem>
-
-        </List>
-      </Box>
-    </>
+          }}
+          disableRipple
+          disabled={!activeMenuItem.backTo}
+          component={NavLink}
+          to={activeMenuItem.backTo ?? "/"}
+        >
+          {activeMenuItem.backTo && <KeyboardArrowLeftIcon sx={{ fontSize: "1rem" }} />} {activeMenuItem.text}
+        </ListItemButton>
+      }
+    >
+      {activeMenuItem.subItems?.map(({ key, ...item }) => (
+        <SidebarItem
+          key={key}
+          onClick={() => navigate(item.subItems?.[0].to ?? "/")}
+          {...item}
+        />
+      ))}
+    </List>
   );
 };

--- a/src/components/Sidebar/defaultSidebarItems.tsx
+++ b/src/components/Sidebar/defaultSidebarItems.tsx
@@ -1,0 +1,144 @@
+import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
+import CreditCardOutlinedIcon from "@mui/icons-material/CreditCardOutlined";
+import ExposureOutlinedIcon from "@mui/icons-material/ExposureOutlined";
+import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
+import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
+import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
+import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
+import ContentPasteOutlinedIcon from "@mui/icons-material/ContentPasteOutlined";
+import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
+import LocalOfferOutlinedIcon from "@mui/icons-material/LocalOfferOutlined";
+import CategoryOutlinedIcon from "@mui/icons-material/CategoryOutlined";
+
+import { SidebarItemProps } from "./SidebarItem";
+
+
+export const FEATURE_KEYS = {
+  dashboard: "dashboard",
+  storefront: "storefront",
+  products: "products",
+  orders: "orders",
+  customers: "customers",
+  promotions: "promotions",
+  settings: "settings",
+  users: "users",
+  shopDetails: "shopDetails",
+  payments: "payments",
+  taxes: "taxes",
+  shippingFulfillment: "shippingFulfillment",
+  categories: "categories",
+  emails: "emails",
+  stores: "stores"
+};
+
+export type ItemProps = SidebarItemProps & {
+  subItems?: ItemProps[]
+  backTo?: string
+  key: string
+}
+
+
+export type SidebarFeaturesProps = {
+  coreFeatures: ItemProps[]
+  plugins?: ItemProps[]
+}
+
+
+export const STOREFRONT_FEATURES: ItemProps[] = [
+  {
+    key: FEATURE_KEYS.dashboard,
+    text: "Dashboard",
+    to: "/",
+    icon: <HomeOutlinedIcon fontSize="small" />
+  },
+  {
+    key: FEATURE_KEYS.storefront,
+    text: "View Storefront",
+    to: "/storefront",
+    icon: <OpenInNewOutlinedIcon fontSize="small" />
+  }
+];
+
+export const CORE_FEATURES: ItemProps[] = [
+  {
+    key: FEATURE_KEYS.products,
+    text: "Products",
+    to: "/products",
+    icon: <ContentPasteOutlinedIcon fontSize="small" />
+  },
+  {
+    key: FEATURE_KEYS.orders,
+    text: "Orders",
+    to: "/orders",
+    icon: <ReceiptLongOutlinedIcon fontSize="small" />
+  },
+  {
+    key: "customers",
+    text: "Customers",
+    to: "/customers",
+    icon: <GroupOutlinedIcon fontSize="small" />
+  },
+  {
+    key: FEATURE_KEYS.promotions,
+    text: "Promotions",
+    to: "/promotions",
+    icon: <LocalOfferOutlinedIcon fontSize="small" />
+  },
+  {
+    key: FEATURE_KEYS.categories,
+    text: "Categories",
+    to: "/categories",
+    icon: <CategoryOutlinedIcon fontSize="small" />
+  },
+  {
+    key: FEATURE_KEYS.settings,
+    text: "Settings",
+    icon: <SettingsOutlinedIcon fontSize="small" />,
+    backTo: "/products",
+    subItems: [
+      {
+        key: FEATURE_KEYS.settings,
+        text: "Users & Permissions",
+        icon: <GroupOutlinedIcon fontSize="small" />,
+        to: "/settings/users"
+      },
+      {
+        key: FEATURE_KEYS.shopDetails,
+        text: "Shop Details",
+        icon: <FactCheckOutlinedIcon fontSize="small" />,
+        to: "/settings/shop-details"
+      },
+      {
+        key: FEATURE_KEYS.payments,
+        text: "Payments",
+        icon: <CreditCardOutlinedIcon fontSize="small" />,
+        to: "/settings/payments"
+      },
+      {
+        key: FEATURE_KEYS.taxes,
+        text: "Taxes",
+        icon: <ExposureOutlinedIcon fontSize="small" />,
+        to: "/settings/taxes"
+      },
+      {
+        key: FEATURE_KEYS.shippingFulfillment,
+        text: "Shipping & Fulfillment",
+        icon: <LocalShippingOutlinedIcon fontSize="small" />,
+        to: "/settings/shipping-fulfillment"
+      },
+      {
+        key: FEATURE_KEYS.emails,
+        text: "Transactional Emails",
+        icon: <EmailOutlinedIcon fontSize="small" />,
+        to: "/settings/emails"
+      }
+    ]
+  }
+];
+
+export const SIDEBAR_ITEMS: SidebarFeaturesProps =
+{
+  coreFeatures: CORE_FEATURES
+};

--- a/src/components/Sidebar/index.ts
+++ b/src/components/Sidebar/index.ts
@@ -1,2 +1,3 @@
 export { Sidebar } from "./Sidebar";
 export * from "./SidebarItem";
+export * from "./defaultSidebarItems";

--- a/src/containers/AccountProvider/index.tsx
+++ b/src/containers/AccountProvider/index.tsx
@@ -33,7 +33,7 @@ export const useAccount = () => {
 };
 
 type AccountProviderProps = {
-  children: JSX.Element
+  children: JSX.Element | null
 }
 
 export const AccountProvider = ({ children }: AccountProviderProps) => {

--- a/src/containers/Layouts/AppLayout.tsx
+++ b/src/containers/Layouts/AppLayout.tsx
@@ -3,11 +3,15 @@ import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
 import { Outlet } from "react-router-dom";
 
-import { Sidebar } from "@components/Sidebar";
+import { Sidebar, SidebarFeaturesProps } from "@components/Sidebar";
 import { AppHeader } from "@components/AppHeader";
 import { SIDEBAR_WIDTH } from "../../constants";
 
-export const AppLayout = () => {
+type AppLayoutProps = {
+  sidebar?: SidebarFeaturesProps
+}
+
+export const AppLayout = ({ sidebar }: AppLayoutProps) => {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
@@ -15,7 +19,7 @@ export const AppLayout = () => {
   return (
     <Box sx={{ display: "flex" }}>
       <AppHeader handleDrawerToggle={handleDrawerToggle} />
-      <Sidebar mobileOpen={mobileOpen} handleDrawerToggle={handleDrawerToggle} />
+      <Sidebar mobileOpen={mobileOpen} handleDrawerToggle={handleDrawerToggle} sidebar={sidebar} />
       <Box component="main" sx={{ flexGrow: 1, width: { xs: "100%", sm: `calc(100% - ${SIDEBAR_WIDTH}px)` } }}>
         <Toolbar />
         <Outlet />

--- a/src/containers/Layouts/PageLayout.tsx
+++ b/src/containers/Layouts/PageLayout.tsx
@@ -1,0 +1,18 @@
+import Container from "@mui/material/Container";
+import { Outlet } from "react-router-dom";
+
+import { SubHeader, SubHeaderItemProps } from "@components/AppHeader";
+
+type PageLayoutProps = {
+  headers?: SubHeaderItemProps[]
+  noPadding?: boolean
+}
+
+export const PageLayout = ({ headers, noPadding = false }: PageLayoutProps) => (
+  <>
+    {headers ? <SubHeader items={headers} /> : null}
+    <Container sx={{ ...(!noPadding && { padding: "20px 30px" }) }} maxWidth={false}>
+      <Outlet/>
+    </Container>
+  </>
+);

--- a/src/containers/Layouts/index.ts
+++ b/src/containers/Layouts/index.ts
@@ -1,2 +1,3 @@
 export { AppLayout } from "./AppLayout";
 export { FullHeightLayout } from "./FullHeightLayout";
+export { PageLayout } from "./PageLayout";

--- a/src/containers/RoutesProvider/index.tsx
+++ b/src/containers/RoutesProvider/index.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext } from "react";
+import { RouteObject } from "react-router-dom";
+
+type RoutesContextProps = {
+  routes: RouteObject[]
+}
+
+const RoutesContext = createContext<RoutesContextProps>({ routes: [] });
+
+/*
+ * A tree traversal search of the routes tree.
+ */
+function findRoute(routes: RouteObject[], path: string) {
+  const queue = [...routes];
+
+  while (queue.length > 0) {
+    const route = queue.shift();
+
+    if (route?.path === path) {
+      return route;
+    }
+
+    if (route?.children) {
+      queue.push(...route.children);
+    }
+  }
+
+  return null;
+}
+
+export const useRoutes = () => {
+  const routesContext = useContext(RoutesContext);
+  if (!routesContext) {
+    throw new Error("useRoutes must be used within a RoutesProvider");
+  }
+
+  return routesContext.routes;
+};
+
+/*
+ * Find a route by its path in the routes' tree
+ */
+export const useRoute = (path: string) => {
+  const routes = useRoutes();
+
+  return findRoute(routes, path);
+};
+
+type RoutesProviderProps = {
+  children: JSX.Element
+  routes: RouteObject[]
+}
+
+
+export const RoutesProvider = ({ children, routes }: RoutesProviderProps) => (
+  <RoutesContext.Provider value={{ routes }}>{children}</RoutesContext.Provider>
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { ThemeProvider } from "@mui/material/styles";
 import { BrowserRouter } from "react-router-dom";
 
+import { RoutesProvider } from "@containers/RoutesProvider";
+
 import theme from "./theme";
 import App from "./App";
 
@@ -13,6 +15,7 @@ import "@fontsource/inter/400.css";
 import "@fontsource/inter/500.css";
 import "@fontsource/inter/600.css";
 import "@fontsource/inter/700.css";
+import { routes } from "./routes";
 
 const queryClient = new QueryClient();
 
@@ -20,9 +23,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(<React.StrictMode>
   <ThemeProvider theme={theme}>
     <CssBaseline />
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <RoutesProvider routes={routes}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </RoutesProvider>
     </QueryClientProvider>
   </ThemeProvider>
 </React.StrictMode>);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import CssBaseline from "@mui/material/CssBaseline";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ThemeProvider } from "@mui/material/styles";
+import { BrowserRouter } from "react-router-dom";
 
 import theme from "./theme";
 import App from "./App";
@@ -19,7 +20,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(<React.StrictMode>
   <ThemeProvider theme={theme}>
     <CssBaseline />
     <QueryClientProvider client={queryClient}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </QueryClientProvider>
   </ThemeProvider>
 </React.StrictMode>);

--- a/src/pages/Settings/ShippingAndFulfillment/index.tsx
+++ b/src/pages/Settings/ShippingAndFulfillment/index.tsx
@@ -1,33 +1,20 @@
-import { Outlet } from "react-router-dom";
-import Container from "@mui/material/Container";
+import { SubHeaderItemProps } from "@components/AppHeader";
 
-import { SubHeader, SubHeaderItemProps } from "@components/AppHeader";
-
-const headers: SubHeaderItemProps[] = [
+export const HEADERS: SubHeaderItemProps[] = [
   {
     label: "Methods",
-    href: "",
+    path: "",
     key: "methods"
   },
   {
     label: "Restrictions",
-    href: "restrictions",
+    path: "restrictions",
     key: "restrictions"
   },
   {
     label: "Surcharges",
-    href: "surcharges",
+    path: "surcharges",
     key: "surcharges"
   }
 ];
 
-const ShippingConfiguration = () => (
-  <>
-    <SubHeader items={headers} />
-    <Container sx={{ padding: "20px 30px" }} maxWidth={false}>
-      <Outlet/>
-    </Container>
-  </>
-);
-
-export default ShippingConfiguration;

--- a/src/pages/Settings/ShippingAndFulfillment/index.tsx
+++ b/src/pages/Settings/ShippingAndFulfillment/index.tsx
@@ -1,20 +1,18 @@
+import { useMemo } from "react";
+
+import { PageLayout } from "@containers/Layouts";
+import { useRoute } from "@containers/RoutesProvider";
 import { SubHeaderItemProps } from "@components/AppHeader";
 
-export const HEADERS: SubHeaderItemProps[] = [
-  {
-    label: "Methods",
-    path: "",
-    key: "methods"
-  },
-  {
-    label: "Restrictions",
-    path: "restrictions",
-    key: "restrictions"
-  },
-  {
-    label: "Surcharges",
-    path: "surcharges",
-    key: "surcharges"
-  }
-];
+export default function ShippingAndFulfillment() {
+  const route = useRoute("shipping-fulfillment");
+
+  const headers = useMemo<SubHeaderItemProps[]>(() => route?.children?.map((child) => ({
+    label: child.title || "",
+    path: child.path || "",
+    key: child.path || ""
+  })) || [], [route]);
+
+  return <PageLayout headers={headers}/>;
+}
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,11 +2,11 @@ import { RouteObject } from "react-router-dom";
 import { lazy } from "react";
 
 import { RequireAuthRoute, RequireShopRoute, UnauthenticatedRoute } from "@components/Routes";
-import { AppLayout, PageLayout } from "@containers/Layouts";
+import { AppLayout } from "@containers/Layouts";
 
 import Dashboard from "./pages/Dashboard";
-import { HEADERS } from "./pages/Settings/ShippingAndFulfillment";
 import NotFound from "./pages/NotFound";
+import ShippingAndFulfillment from "./pages/Settings/ShippingAndFulfillment";
 
 const Login = lazy(() => import("./pages/Login"));
 const SignUp = lazy(() => import("./pages/SignUp"));
@@ -62,19 +62,22 @@ export const routes: RouteObject[] = [
                 children: [
                   {
                     path: "shipping-fulfillment",
-                    element: <PageLayout headers={HEADERS}/>,
+                    element: <ShippingAndFulfillment/>,
                     children: [
                       {
                         index: true,
-                        element: <ShippingMethods/>
+                        element: <ShippingMethods/>,
+                        title: "Methods"
                       },
                       {
                         path: "surcharges",
-                        element: <ShippingSurcharges/>
+                        element: <ShippingSurcharges/>,
+                        title: "Surcharges"
                       },
                       {
                         path: "restrictions",
-                        element: <ShippingRestrictions/>
+                        element: <ShippingRestrictions/>,
+                        title: "Restrictions"
                       }
                     ]
                   }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,124 @@
+import { RouteObject } from "react-router-dom";
+import { lazy } from "react";
+import LocalMallIcon from "@mui/icons-material/LocalMall";
+
+import { RequireAuthRoute, RequireShopRoute, UnauthenticatedRoute } from "@components/Routes";
+import { AppLayout, PageLayout } from "@containers/Layouts";
+import { FEATURE_KEYS, SIDEBAR_ITEMS } from "@components/Sidebar";
+
+import Dashboard from "./pages/Dashboard";
+import { HEADERS } from "./pages/Settings/ShippingAndFulfillment";
+import NotFound from "./pages/NotFound";
+
+const Login = lazy(() => import("./pages/Login"));
+const SignUp = lazy(() => import("./pages/SignUp"));
+const PasswordReset = lazy(() => import("./pages/PasswordReset"));
+const NewPassword = lazy(() => import("./pages/NewPassword"));
+const ShippingMethods = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Methods"));
+const ShippingSurcharges = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Surcharges"));
+const ShippingRestrictions = lazy(() => import("./pages/Settings/ShippingAndFulfillment/Restrictions"));
+const CreateShop = lazy(() => import("./pages/CreateShop"));
+
+export const routes: RouteObject[] = [
+  {
+    element: <UnauthenticatedRoute/>,
+    children: [
+      {
+        path: "/signup",
+        element: <SignUp/>
+      },
+      {
+        path: "/login",
+        element: <Login/>
+      },
+      {
+        path: "/password-reset/new",
+        element: <PasswordReset/>
+      },
+      {
+        path: "/password-reset",
+        element: <NewPassword/>
+      }
+    ]
+  },
+  {
+    element: <RequireAuthRoute/>,
+    children: [
+      {
+        path: "/new-shop",
+        element: <CreateShop/>
+      },
+      {
+        element: <RequireShopRoute/>,
+        children: [
+          {
+            path: "/",
+            element: <AppLayout
+              sidebar={{
+                coreFeatures: SIDEBAR_ITEMS.coreFeatures.map((features) => {
+                  if (features.key === FEATURE_KEYS.settings) {
+                    return {
+                      ...features,
+                      subItems: [...(features.subItems ? features.subItems : []), {
+                        key: "newSetting",
+                        text: "New Settings",
+                        to: "/new-settings"
+                      }]
+                    };
+                  }
+
+                  return features;
+                }),
+                plugins: [
+                  {
+                    text: "Plugins",
+                    key: "plugins",
+                    subItems: [
+                      {
+                        text: "Store Pickup",
+                        icon: <LocalMallIcon fontSize="small" />,
+                        to: "/pickup",
+                        key: "storePickup"
+                      }]
+                  }
+                ]
+              }}/>,
+            children: [
+              {
+                index: true,
+                element: <Dashboard/>
+              },
+              {
+                path: "settings",
+                children: [
+                  {
+                    path: "shipping-fulfillment",
+                    element: <PageLayout headers={HEADERS}/>,
+                    children: [
+                      {
+                        index: true,
+                        element: <ShippingMethods/>
+                      },
+                      {
+                        path: "surcharges",
+                        element: <ShippingSurcharges/>
+                      },
+                      {
+                        path: "restrictions",
+                        element: <ShippingRestrictions/>
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                path: "*",
+                element: <NotFound />
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,10 +1,8 @@
 import { RouteObject } from "react-router-dom";
 import { lazy } from "react";
-import LocalMallIcon from "@mui/icons-material/LocalMall";
 
 import { RequireAuthRoute, RequireShopRoute, UnauthenticatedRoute } from "@components/Routes";
 import { AppLayout, PageLayout } from "@containers/Layouts";
-import { FEATURE_KEYS, SIDEBAR_ITEMS } from "@components/Sidebar";
 
 import Dashboard from "./pages/Dashboard";
 import { HEADERS } from "./pages/Settings/ShippingAndFulfillment";
@@ -53,36 +51,7 @@ export const routes: RouteObject[] = [
         children: [
           {
             path: "/",
-            element: <AppLayout
-              sidebar={{
-                coreFeatures: SIDEBAR_ITEMS.coreFeatures.map((features) => {
-                  if (features.key === FEATURE_KEYS.settings) {
-                    return {
-                      ...features,
-                      subItems: [...(features.subItems ? features.subItems : []), {
-                        key: "newSetting",
-                        text: "New Settings",
-                        to: "/new-settings"
-                      }]
-                    };
-                  }
-
-                  return features;
-                }),
-                plugins: [
-                  {
-                    text: "Plugins",
-                    key: "plugins",
-                    subItems: [
-                      {
-                        text: "Store Pickup",
-                        icon: <LocalMallIcon fontSize="small" />,
-                        to: "/pickup",
-                        key: "storePickup"
-                      }]
-                  }
-                ]
-              }}/>,
+            element: <AppLayout/>,
             children: [
               {
                 index: true,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,9 @@
+declare module "react-router-dom" {
+  interface RouteObject {
+    title?: string;
+  }
+}
+
 export type Error = {
   extensions: {
     code: string


### PR DESCRIPTION
By extending the RouteObject type definitions we can add custom properties to the routes.

An example would be a title. This property can be displayed in the browser tab title, as well as in the page layout headers.

Another proposal in this PR is to add all route definitions in a context. This will allow components to access the route definitions. An example use case would be to render page layout headers dynamically based on the page children.