### PR TITLE
Attach Homepage URL to 'View Storefront' Link

### DIFF
--- a/src/components/Sidebar/ProfileToolbar.tsx
+++ b/src/components/Sidebar/ProfileToolbar.tsx
@@ -21,7 +21,7 @@ export const ProfileToolbar = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const { account, removeAccessToken } = useAccount();
-  const { shopId, setShopId } = useShop();
+  const { shopId, setShop, shop: activeShop } = useShop();
 
   const open = Boolean(anchorEl);
 
@@ -33,7 +33,6 @@ export const ProfileToolbar = () => {
     setAnchorEl(null);
   };
 
-  const activeShop = account?.adminUIShops?.find((shop) => shop?._id === shopId);
 
   const showShopList = account?.adminUIShops?.length && account.adminUIShops.length > 1;
 
@@ -106,7 +105,7 @@ export const ProfileToolbar = () => {
 
         {showShopList
           ? account?.adminUIShops?.map((shop) => (
-            <MenuItem key={shop?._id} onClick={() => setShopId(shop?._id)}>
+            <MenuItem key={shop?._id} onClick={() => setShop(shop)}>
               {shop?._id === shopId ? (
                 <ListItemIcon>
                   <Check />

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -46,7 +46,8 @@ export const SidebarContent = ({ sidebar = SIDEBAR_ITEMS }: SidebarItemsProps) =
               key="storefront"
               icon={<OpenInNewOutlinedIcon fontSize="small" />}
               text="View Storefront"
-              onClick={() => window.open(`${activeShop?.storefrontUrls?.storefrontHomeUrl || "/"}`, "_blank")} />
+              onClick={activeShop?.storefrontUrls?.storefrontHomeUrl ?
+                () => window.open(`${activeShop?.storefrontUrls?.storefrontHomeUrl}`, "_blank") : undefined} />
           </List>
           <Divider sx={{ mx: 2, borderColor: "background.darkGrey" }} />
           {coreFeatures.length ? <SidebarItems items={[{ text: "Stores", key: FEATURE_KEYS.stores, subItems: coreFeatures }]}/> : null}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -5,12 +5,16 @@ import SupportOutlinedIcon from "@mui/icons-material/SupportOutlined";
 import Typography from "@mui/material/Typography";
 import ListItem from "@mui/material/ListItem";
 import Link from "@mui/material/Link";
+import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
+import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
 
 import { SystemInformation } from "@components/SystemInformation";
+import { useAccount } from "@containers/AccountProvider";
+import { useShop } from "@containers/ShopProvider";
 
 import { SidebarItem } from "./SidebarItem";
 import { ProfileToolbar } from "./ProfileToolbar";
-import { CORE_FEATURES, FEATURE_KEYS, SidebarFeaturesProps, SIDEBAR_ITEMS, STOREFRONT_FEATURES } from "./defaultSidebarItems";
+import { CORE_FEATURES, FEATURE_KEYS, SidebarFeaturesProps, SIDEBAR_ITEMS } from "./defaultSidebarItems";
 import { SidebarItems } from "./SidebarItems";
 
 
@@ -20,6 +24,9 @@ type SidebarItemsProps = {
 
 export const SidebarContent = ({ sidebar = SIDEBAR_ITEMS }: SidebarItemsProps) => {
   const { coreFeatures = CORE_FEATURES, plugins = [] } = sidebar;
+  const { account } = useAccount();
+  const { shopId } = useShop();
+  const activeShop = account?.adminUIShops?.find((shop) => shop?._id === shopId);
 
   return (
     <>
@@ -34,9 +41,12 @@ export const SidebarContent = ({ sidebar = SIDEBAR_ITEMS }: SidebarItemsProps) =
       >
         <Box>
           <List>
-            {STOREFRONT_FEATURES.map(({ text, icon, to }) => (
-              <SidebarItem key={text} icon={icon} to={to} text={text} />
-            ))}
+            <SidebarItem key="dashboard" icon={<HomeOutlinedIcon fontSize="small" />} to="/" text="Dashboard" />
+            <SidebarItem
+              key="storefront"
+              icon={<OpenInNewOutlinedIcon fontSize="small" />}
+              text="View Storefront"
+              onClick={() => window.open(`${activeShop?.storefrontUrls?.storefrontHomeUrl || "/"}`, "_blank")} />
           </List>
           <Divider sx={{ mx: 2, borderColor: "background.darkGrey" }} />
           {coreFeatures.length ? <SidebarItems items={[{ text: "Stores", key: FEATURE_KEYS.stores, subItems: coreFeatures }]}/> : null}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -9,7 +9,6 @@ import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
 
 import { SystemInformation } from "@components/SystemInformation";
-import { useAccount } from "@containers/AccountProvider";
 import { useShop } from "@containers/ShopProvider";
 
 import { SidebarItem } from "./SidebarItem";
@@ -24,9 +23,7 @@ type SidebarItemsProps = {
 
 export const SidebarContent = ({ sidebar = SIDEBAR_ITEMS }: SidebarItemsProps) => {
   const { coreFeatures = CORE_FEATURES, plugins = [] } = sidebar;
-  const { account } = useAccount();
-  const { shopId } = useShop();
-  const activeShop = account?.adminUIShops?.find((shop) => shop?._id === shopId);
+  const { shop: activeShop } = useShop();
 
   return (
     <>

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -60,6 +60,7 @@ export const SidebarItem = ({ to, onClick, ...props }: SidebarItemProps) => (
         dense
         sx={sharedStyles}
         onClick={onClick}
+        disabled={!onClick}
       >
         {props.icon ? <ListItemIcon>{props.icon}</ListItemIcon> : null}
         <ListItemText primary={props.text} />

--- a/src/components/Sidebar/defaultSidebarItems.tsx
+++ b/src/components/Sidebar/defaultSidebarItems.tsx
@@ -2,10 +2,8 @@ import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
 import CreditCardOutlinedIcon from "@mui/icons-material/CreditCardOutlined";
 import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
 import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
-import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
-import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
 import ContentPasteOutlinedIcon from "@mui/icons-material/ContentPasteOutlined";
 import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
 import LocalOfferOutlinedIcon from "@mui/icons-material/LocalOfferOutlined";
@@ -16,8 +14,6 @@ import { SidebarItemProps } from "./SidebarItem";
 
 
 export const FEATURE_KEYS = {
-  dashboard: "dashboard",
-  storefront: "storefront",
   products: "products",
   orders: "orders",
   customers: "customers",
@@ -43,22 +39,6 @@ export type SidebarFeaturesProps = {
   coreFeatures?: ItemProps[]
   plugins?: ItemProps[]
 }
-
-
-export const STOREFRONT_FEATURES: ItemProps[] = [
-  {
-    key: FEATURE_KEYS.dashboard,
-    text: "Dashboard",
-    to: "/",
-    icon: <HomeOutlinedIcon fontSize="small" />
-  },
-  {
-    key: FEATURE_KEYS.storefront,
-    text: "View Storefront",
-    to: "/storefront",
-    icon: <OpenInNewOutlinedIcon fontSize="small" />
-  }
-];
 
 export const CORE_FEATURES: ItemProps[] = [
   {

--- a/src/containers/AccountProvider/index.tsx
+++ b/src/containers/AccountProvider/index.tsx
@@ -46,7 +46,7 @@ export const AccountProvider = ({ children }: AccountProviderProps) => {
     client.setHeaders({});
   }
 
-  const { setShopId, shopId } = useShop();
+  const { setShop, shopId } = useShop();
   const location = useLocation();
   const navigate = useNavigate();
   const redirectUrl = (new URLSearchParams(location.search)).get("redirectUrl");
@@ -60,11 +60,14 @@ export const AccountProvider = ({ children }: AccountProviderProps) => {
     },
     onSuccess: (response) => {
       if (response.viewer === null) {
-        setShopId();
+        setShop();
         return;
       }
 
-      !shopId && setShopId(response.viewer?.adminUIShops?.find((shop) => shop?.shopType === "primary")?._id);
+      if (!shopId) {
+        const primaryShop = response.viewer?.adminUIShops?.find((shop) => shop?.shopType === "primary");
+        setShop(primaryShop);
+      }
       redirectUrl && navigate(redirectUrl);
     }
   });

--- a/src/containers/AccountProvider/viewer.graphql
+++ b/src/containers/AccountProvider/viewer.graphql
@@ -22,6 +22,13 @@ query getViewer {
       shopLogoUrls {
         primaryShopLogoUrl
       }
+      currency {
+        _id
+        code
+        format
+        symbol
+      },
+      language
     }
   }
 }

--- a/src/containers/AccountProvider/viewer.graphql
+++ b/src/containers/AccountProvider/viewer.graphql
@@ -13,6 +13,9 @@ query getViewer {
           large
         }
       }
+      storefrontUrls {
+        storefrontHomeUrl
+      }
       name
       slug
       shopType

--- a/src/containers/ShopProvider/index.tsx
+++ b/src/containers/ShopProvider/index.tsx
@@ -1,12 +1,15 @@
 import { createContext, useContext, useState } from "react";
 import { noop } from "lodash-es";
 
+import { Shop } from "types/shop";
+
 type ShopContextProps = {
   shopId?: string
-  setShopId: (shopId?: string) => void
+  setShop: (shop?: Shop | null) => void
+  shop?: Shop | null
 }
 
-const ShopContext = createContext<ShopContextProps>({ shopId: undefined, setShopId: noop });
+const ShopContext = createContext<ShopContextProps>({ shopId: undefined, setShop: noop });
 
 export const useShop = () => {
   const shopContext = useContext(ShopContext);
@@ -22,7 +25,7 @@ type ShopProviderProps = {
 }
 
 export const ShopProvider = ({ children }: ShopProviderProps) => {
-  const [shopId, setShopId] = useState<string>();
+  const [shop, setShop] = useState<Shop | null>();
 
-  return <ShopContext.Provider value={{ shopId, setShopId }}>{children}</ShopContext.Provider>;
+  return <ShopContext.Provider value={{ shopId: shop?._id, setShop, shop }}>{children}</ShopContext.Provider>;
 };

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -8138,7 +8138,7 @@ export type SystemInformationQuery = { __typename?: 'Query', systemInformation: 
 export type GetViewerQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Account', _id: string, firstName?: string | null, language?: string | null, lastName?: string | null, name?: string | null, primaryEmailAddress: any, adminUIShops?: Array<{ __typename?: 'Shop', _id: string, name: string, slug?: string | null, shopType?: string | null, brandAssets?: { __typename?: 'ShopBrandAssets', navbarBrandImage?: { __typename?: 'ImageSizes', large?: string | null } | null } | null, shopLogoUrls?: { __typename?: 'ShopLogoUrls', primaryShopLogoUrl?: string | null } | null } | null> | null } | null };
+export type GetViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Account', _id: string, firstName?: string | null, language?: string | null, lastName?: string | null, name?: string | null, primaryEmailAddress: any, adminUIShops?: Array<{ __typename?: 'Shop', _id: string, name: string, slug?: string | null, shopType?: string | null, brandAssets?: { __typename?: 'ShopBrandAssets', navbarBrandImage?: { __typename?: 'ImageSizes', large?: string | null } | null } | null, storefrontUrls?: { __typename?: 'StorefrontUrls', storefrontHomeUrl?: string | null } | null, shopLogoUrls?: { __typename?: 'ShopLogoUrls', primaryShopLogoUrl?: string | null } | null } | null> | null } | null };
 
 export type CreateShopMutationVariables = Exact<{
   input: CreateShopInput;
@@ -8592,6 +8592,9 @@ export const GetViewerDocument = `
         navbarBrandImage {
           large
         }
+      }
+      storefrontUrls {
+        storefrontHomeUrl
       }
       name
       slug

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -8138,14 +8138,14 @@ export type SystemInformationQuery = { __typename?: 'Query', systemInformation: 
 export type GetViewerQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Account', _id: string, firstName?: string | null, language?: string | null, lastName?: string | null, name?: string | null, primaryEmailAddress: any, adminUIShops?: Array<{ __typename?: 'Shop', _id: string, name: string, slug?: string | null, shopType?: string | null, brandAssets?: { __typename?: 'ShopBrandAssets', navbarBrandImage?: { __typename?: 'ImageSizes', large?: string | null } | null } | null, storefrontUrls?: { __typename?: 'StorefrontUrls', storefrontHomeUrl?: string | null } | null, shopLogoUrls?: { __typename?: 'ShopLogoUrls', primaryShopLogoUrl?: string | null } | null } | null> | null } | null };
+export type GetViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Account', _id: string, firstName?: string | null, language?: string | null, lastName?: string | null, name?: string | null, primaryEmailAddress: any, adminUIShops?: Array<{ __typename?: 'Shop', _id: string, name: string, slug?: string | null, shopType?: string | null, language: string, brandAssets?: { __typename?: 'ShopBrandAssets', navbarBrandImage?: { __typename?: 'ImageSizes', large?: string | null } | null } | null, storefrontUrls?: { __typename?: 'StorefrontUrls', storefrontHomeUrl?: string | null } | null, shopLogoUrls?: { __typename?: 'ShopLogoUrls', primaryShopLogoUrl?: string | null } | null, currency: { __typename?: 'Currency', _id: string, code: string, format: string, symbol: string } } | null> | null } | null };
 
 export type CreateShopMutationVariables = Exact<{
   input: CreateShopInput;
 }>;
 
 
-export type CreateShopMutation = { __typename?: 'Mutation', createShop: { __typename?: 'CreateShopPayload', shop: { __typename?: 'Shop', _id: string } } };
+export type CreateShopMutation = { __typename?: 'Mutation', createShop: { __typename?: 'CreateShopPayload', shop: { __typename?: 'Shop', _id: string, language: string, name: string, currency: { __typename?: 'Currency', _id: string, code: string, format: string, symbol: string } } } };
 
 export type AuthenticateMutationVariables = Exact<{
   serviceName: Scalars['String'];
@@ -8436,7 +8436,7 @@ export type UpdateShopMutationVariables = Exact<{
 }>;
 
 
-export type UpdateShopMutation = { __typename?: 'Mutation', updateShop: { __typename?: 'UpdateShopPayload', shop: { __typename?: 'Shop', _id: string } } };
+export type UpdateShopMutation = { __typename?: 'Mutation', updateShop: { __typename?: 'UpdateShopPayload', shop: { __typename?: 'Shop', _id: string, language: string, name: string, currency: { __typename?: 'Currency', _id: string, code: string, format: string, symbol: string }, storefrontUrls?: { __typename?: 'StorefrontUrls', storefrontHomeUrl?: string | null } | null } } };
 
 export type GetGroupsQueryVariables = Exact<{
   shopId: Scalars['ID'];
@@ -8602,6 +8602,13 @@ export const GetViewerDocument = `
       shopLogoUrls {
         primaryShopLogoUrl
       }
+      currency {
+        _id
+        code
+        format
+        symbol
+      }
+      language
     }
   }
 }
@@ -8625,6 +8632,14 @@ export const CreateShopDocument = `
   createShop(input: $input) {
     shop {
       _id
+      currency {
+        _id
+        code
+        format
+        symbol
+      }
+      language
+      name
     }
   }
 }
@@ -9630,6 +9645,17 @@ export const UpdateShopDocument = `
   updateShop(input: $input) {
     shop {
       _id
+      currency {
+        _id
+        code
+        format
+        symbol
+      }
+      language
+      name
+      storefrontUrls {
+        storefrontHomeUrl
+      }
     }
   }
 }

--- a/src/mocks/handlers/shopSettingsHandlers.ts
+++ b/src/mocks/handlers/shopSettingsHandlers.ts
@@ -56,7 +56,7 @@ const getShopHandler = graphql.query("getShop", (req, res, ctx) => res(ctx.data(
 
 const updateShopHandler = graphql.mutation("updateShop", (req, res, ctx) => {
   const { input } = req.variables;
-  return res(ctx.data({ input }));
+  return res(ctx.data({ updateShop: { shop: input } }));
 });
 
 export const handlers = [

--- a/src/pages/CreateShop/createShop.graphql
+++ b/src/pages/CreateShop/createShop.graphql
@@ -2,6 +2,14 @@ mutation createShop($input: CreateShopInput!) {
   createShop(input: $input) {
     shop {
       _id
+      currency {
+        _id
+        code
+        format
+        symbol
+      }
+      language
+      name
     }
   }
 }

--- a/src/pages/CreateShop/index.tsx
+++ b/src/pages/CreateShop/index.tsx
@@ -37,7 +37,7 @@ const CreateShop = () => {
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string>();
   const { mutate } = useCreateShopMutation(client);
   const navigate = useNavigate();
-  const { setShopId, shopId } = useShop();
+  const { setShop, shopId } = useShop();
   const { refetchAccount, removeAccessToken } = useAccount();
 
   const handleClickSignIn = () => {
@@ -56,7 +56,7 @@ const CreateShop = () => {
           setSubmitErrorMessage(normalizeErrorMessage((error as GraphQLErrorResponse).response.errors));
         },
         onSuccess: (data) => {
-          setShopId(data.createShop.shop._id);
+          setShop(data.createShop.shop);
           refetchAccount();
           navigate("/", { replace: true });
         }

--- a/src/pages/Settings/Emails/Templates/EmailTemplates.test.tsx
+++ b/src/pages/Settings/Emails/Templates/EmailTemplates.test.tsx
@@ -57,7 +57,7 @@ describe("Email Templates", () => {
 
     const drawer = screen.getByRole("presentation");
 
-    expect(within(drawer).getByLabelText("Homepage URL")).toHaveValue(emailVariables.storefrontHomeUrl);
+    expect(within(drawer).getByLabelText("Storefront URL")).toHaveValue(emailVariables.storefrontHomeUrl);
     expect(within(drawer).getByLabelText("Login URL")).toHaveValue(emailVariables.storefrontLoginUrl);
     expect(within(drawer).getByLabelText("Single Order Page URL")).toHaveValue(emailVariables.storefrontOrderUrl);
     expect(within(drawer).getByLabelText("Orders Page URL")).toHaveValue(emailVariables.storefrontOrdersUrl);
@@ -72,12 +72,12 @@ describe("Email Templates", () => {
     expect(within(drawer).getByLabelText("Account Profile Page URL")).toBeInvalid();
     await user.clear(within(drawer).getByLabelText("Account Profile Page URL"));
 
-    await user.clear(within(drawer).getByLabelText("Homepage URL"));
-    await user.type(within(drawer).getByLabelText("Homepage URL"), "ftp://fake.com");
+    await user.clear(within(drawer).getByLabelText("Storefront URL"));
+    await user.type(within(drawer).getByLabelText("Storefront URL"), "ftp://fake.com");
     await user.tab();
-    expect(within(drawer).getByLabelText("Homepage URL")).toBeInvalid();
-    await user.clear(within(drawer).getByLabelText("Homepage URL"));
-    await user.type(within(drawer).getByLabelText("Homepage URL"), "https://slingshotstore.com/");
+    expect(within(drawer).getByLabelText("Storefront URL")).toBeInvalid();
+    await user.clear(within(drawer).getByLabelText("Storefront URL"));
+    await user.type(within(drawer).getByLabelText("Storefront URL"), "https://slingshotstore.com/");
 
     await user.click(screen.getByText("Save Changes"));
 

--- a/src/pages/Settings/Emails/Templates/index.tsx
+++ b/src/pages/Settings/Emails/Templates/index.tsx
@@ -239,12 +239,14 @@ const EmailTemplates = () => {
                 <Field
                   component={TextField}
                   name="storefrontHomeUrl"
-                  label="Homepage URL"
+                  label="Storefront URL"
+                  placeholder="Enter you shop homepage URL"
                 />
                 <Field
                   component={TextField}
                   name="storefrontLoginUrl"
                   label="Login URL"
+                  placeholder="Enter you shop login form URL"
                 />
                 <Field
                   component={TextField}
@@ -256,11 +258,13 @@ const EmailTemplates = () => {
                   component={TextField}
                   name="storefrontOrdersUrl"
                   label="Orders Page URL"
+                  placeholder="Enter you shop orders page URL"
                 />
                 <Field
                   component={TextField}
                   name="storefrontAccountProfileUrl"
                   label="Account Profile Page URL"
+                  placeholder="Enter you shop account profile homepage URL"
                 />
               </Drawer.Content>
               <Drawer.Actions

--- a/src/pages/Settings/ShopDetails/shop.graphql
+++ b/src/pages/Settings/ShopDetails/shop.graphql
@@ -55,6 +55,17 @@ mutation updateShop($input: UpdateShopInput!) {
   updateShop(input: $input) {
     shop {
       _id
+      currency {
+        _id
+        code
+        format
+        symbol
+      }
+      language
+      name
+      storefrontUrls {
+        storefrontHomeUrl
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #63 
Testing Instructions:
- Start the app and log in with a valid account
- Navigate to Transactional Emails/Templates
- Click on Configure button

<img width="1014" alt="Screen Shot 2022-10-17 at 16 09 17" src="https://user-images.githubusercontent.com/33818318/196137859-29d6bee6-28c5-4b0e-b3e7-f14c592c3b8f.png">
<img width="641" alt="Screen Shot 2022-10-17 at 16 09 24" src="https://user-images.githubusercontent.com/33818318/196138278-bd265606-2a8c-4166-b28b-c6f54f8de637.png">

- Provide Homepage URL field
- Save Changes and Reload the page
- Click on `View Storefront` button on the sidebar
<img width="274" alt="image" src="https://user-images.githubusercontent.com/33818318/196138209-1d7cd2c8-7e5d-4933-bd18-72a5b266e2c6.png">

