### PR TITLE
Prepare error handler component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { FullPageLoader } from "@components/Loader/FullPageLoader";
 
 import { AccountProvider } from "@containers/AccountProvider";
 import { ShopProvider } from "@containers/ShopProvider";
-import { ToastProvider } from "@containers/ToastProvider";
 
 import { routes } from "./routes";
 
@@ -13,13 +12,11 @@ function App() {
 
   return (
     <Suspense fallback={<FullPageLoader />}>
-      <ToastProvider>
-        <ShopProvider>
-          <AccountProvider>
-            {routeElement}
-          </AccountProvider>
-        </ShopProvider>
-      </ToastProvider>
+      <ShopProvider>
+        <AccountProvider>
+          {routeElement}
+        </AccountProvider>
+      </ShopProvider>
     </Suspense>
   );
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,10 +1,11 @@
 import { Component } from "react";
 import Typography from "@mui/material/Typography";
 
-import { formatErrorResponse } from "@utils/errorHandlers";
+import { formatErrorResponse, isNetworkError } from "@utils/errorHandlers";
 import { ErrorCode } from "types/common";
 
 import { AccessDenied } from "./AccessDenied";
+import { GeneralError } from "./GeneralError";
 
 type Props = {
    children: JSX.Element,
@@ -29,9 +30,19 @@ export class ErrorBoundary extends Component<Props, {hasError: boolean, errorEle
   }
 
   componentDidCatch(error: Error) {
+    this.props.setHasError(true);
+    if (isNetworkError(error)) {
+      this.setState({
+        errorElement:
+        <GeneralError
+          title="Network Error"
+          description="There is a connection error. Please check your internet and try again."
+        />
+      });
+      return;
+    }
     const { code } = formatErrorResponse(error);
 
-    this.props.setHasError(true);
 
     if (this.props.fallback) {
       this.setState({ errorElement: this.props.fallback });

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -36,7 +36,7 @@ export class ErrorBoundary extends Component<Props, {hasError: boolean, errorEle
         errorElement:
         <GeneralError
           title="Network Error"
-          description="There is a connection error. Please check your internet and try again."
+          description="There is an issue when connecting to the API. Please check your API server and try again."
         />
       });
       return;

--- a/src/components/ErrorBoundary/GeneralError.tsx
+++ b/src/components/ErrorBoundary/GeneralError.tsx
@@ -8,7 +8,7 @@ type GeneralErrorProps = {
   description?: string
 }
 
-export const GeneralError = ({ title = "Something went wrong.", description = "Email you shop owner to get access." }:GeneralErrorProps) => (
+export const GeneralError = ({ title = "Something went wrong.", description = "Contact your shop owner to get access." }:GeneralErrorProps) => (
   <FullHeightLayout maxWidth="md">
     <AppLogo theme="dark" sx={{ mb: 3 }} />
     <Typography component="h1" variant="h4" gutterBottom>

--- a/src/components/ErrorBoundary/GeneralError.tsx
+++ b/src/components/ErrorBoundary/GeneralError.tsx
@@ -1,0 +1,19 @@
+import Typography from "@mui/material/Typography";
+
+import { FullHeightLayout } from "@containers/Layouts";
+import { AppLogo } from "@components/AppLogo";
+
+type GeneralErrorProps = {
+  title?: string
+  description?: string
+}
+
+export const GeneralError = ({ title = "Something went wrong.", description = "Email you shop owner to get access." }:GeneralErrorProps) => (
+  <FullHeightLayout maxWidth="md">
+    <AppLogo theme="dark" sx={{ mb: 3 }} />
+    <Typography component="h1" variant="h4" gutterBottom>
+      {title}
+    </Typography>
+    <Typography variant="subtitle1" gutterBottom color="grey.700" noWrap>{description}</Typography>
+  </FullHeightLayout>
+);

--- a/src/containers/AccountProvider/index.tsx
+++ b/src/containers/AccountProvider/index.tsx
@@ -57,9 +57,18 @@ export const AccountProvider = ({ children }: AccountProviderProps) => {
 
   const { data, isLoading, refetch } = useGetViewerQuery(client, undefined, {
     retry: false,
-    useErrorBoundary: false,
+    useErrorBoundary: (error) => {
+      if (!formatErrorResponse(error)) {
+        return true;
+      }
+      return false;
+    },
     onError: (error) => {
-      const { code, status } = formatErrorResponse(error);
+      const formattedError = formatErrorResponse(error);
+      if (!formattedError) {
+        return;
+      }
+      const { code, status } = formattedError;
 
       if (status === 401) removeAccessToken();
       if (code === ErrorCode.Forbidden) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { ThemeProvider } from "@mui/material/styles";
 import { BrowserRouter } from "react-router-dom";
 
+import { ToastProvider } from "@containers/ToastProvider";
+import { ErrorBoundary } from "@components/ErrorBoundary";
+
 import theme from "./theme";
 import App from "./App";
 
@@ -26,10 +29,14 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById("root")!).render(<React.StrictMode>
   <ThemeProvider theme={theme}>
     <CssBaseline />
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ToastProvider>
   </ThemeProvider>
 </React.StrictMode>);

--- a/src/utils/errorHandlers.ts
+++ b/src/utils/errorHandlers.ts
@@ -2,7 +2,7 @@ import { APIErrorResponse, GraphQLErrorResponse } from "types/common";
 
 export const formatErrorResponse = (error: unknown): {code?: string | number, status?: number, message?: string} => {
   const responseError = error as APIErrorResponse | GraphQLErrorResponse;
-  if ("errors" in responseError.response) {
+  if (responseError.response && "errors" in responseError.response) {
     const { errors } = responseError.response;
     const firstError = errors.length ? errors[0] : null;
     const errorCode = firstError?.extensions.exception.code || firstError?.extensions.code;
@@ -10,3 +10,5 @@ export const formatErrorResponse = (error: unknown): {code?: string | number, st
   }
   return responseError.response;
 };
+
+export const isNetworkError = (error: unknown): boolean => (error as Error).message === "Network request failed";


### PR DESCRIPTION
This PR is an improvement for our error handler. Most of the time we should handle errors properly, but in some cases like Network errors or any unexpected error we should notify users and handle them properly instead of displaying an empty page.

Testing Instructions:
- Start the app without running API service and observe

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/33818318/200731332-a8c0ffff-1ad2-43ef-885d-fc2241b26314.png">
