### PR TITLE
Promotions usage limits

### DIFF
--- a/src/pages/Promotions/Details/PromotionActions.tsx
+++ b/src/pages/Promotions/Details/PromotionActions.tsx
@@ -16,6 +16,7 @@ import { AlertDialog } from "@components/Dialog";
 
 import { EligibleItems } from "./EligibleItems";
 import { EligibleShippingMethods } from "./EligibleShippingMethods";
+import { PromotionUsageLimits } from "./PromotionUsageLimits";
 
 type Action = Promotion["actions"][0]
 
@@ -74,6 +75,11 @@ export const PromotionActions = () => {
                   Remove Action
                   </Button>
                 </Stack>
+                <Stack my={1}>
+                  <Typography variant="subtitle2">Promotion Usage Limits</Typography>
+                  <PromotionUsageLimits actionParametersFieldName={`actions[${index}].actionParameters`}/>
+                </Stack>
+
                 {isShippingDiscount ?
                   <EligibleShippingMethods
                     inclusionFieldName={

--- a/src/pages/Promotions/Details/PromotionUsageLimits.tsx
+++ b/src/pages/Promotions/Details/PromotionUsageLimits.tsx
@@ -4,8 +4,9 @@ import { Field } from "formik";
 import { TextField } from "@components/TextField";
 
 export const PromotionUsageLimits = () => (
-  <Stack direction="row" gap={2} mt={1} sx={{ width: { md: "50%", xs: "100%" } }}>
+  <Stack direction="row" gap={2} mt={1} sx={{ width: { md: "80%", xs: "100%" } }}>
     <Field name="maxUsagePerOrder" component={TextField} type="number" label="Max # uses per Order"/>
+    <Field name="maxDiscountPerOrder" component={TextField} type="number" label="Max $ discount on an Order"/>
     <Field name="maxUsagePerCustomer" component={TextField} type="number" label="Max # uses per Customer"/>
   </Stack>
 );

--- a/src/pages/Promotions/Details/PromotionUsageLimits.tsx
+++ b/src/pages/Promotions/Details/PromotionUsageLimits.tsx
@@ -3,10 +3,13 @@ import { Field } from "formik";
 
 import { TextField } from "@components/TextField";
 
-export const PromotionUsageLimits = () => (
-  <Stack direction="row" gap={2} mt={1} sx={{ width: { md: "80%", xs: "100%" } }}>
-    <Field name="maxUsagePerOrder" component={TextField} type="number" label="Max # uses per Order"/>
-    <Field name="maxDiscountPerOrder" component={TextField} type="number" label="Max $ discount on an Order"/>
-    <Field name="maxUsagePerCustomer" component={TextField} type="number" label="Max # uses per Customer"/>
+type PromotionUsageLimitsProps = {
+  actionParametersFieldName: string
+}
+
+export const PromotionUsageLimits = ({ actionParametersFieldName }: PromotionUsageLimitsProps) => (
+  <Stack sx={{ width: { lg: "50%", md: "100%" }, flexDirection: { lg: "row", md: "column" }, gap: { lg: 2, md: 0 } }} alignItems="center">
+    <Field name={`${actionParametersFieldName}.discountMaxUnits`} component={TextField} type="number" label="Max # uses per Order" />
+    <Field name={`${actionParametersFieldName}.discountMaxValue`} component={TextField} type="number" label="Max $ discount on an Order" />
   </Stack>
 );

--- a/src/pages/Promotions/Details/PromotionUsageLimits.tsx
+++ b/src/pages/Promotions/Details/PromotionUsageLimits.tsx
@@ -1,0 +1,11 @@
+import Stack from "@mui/material/Stack";
+import { Field } from "formik";
+
+import { TextField } from "@components/TextField";
+
+export const PromotionUsageLimits = () => (
+  <Stack direction="row" gap={2} mt={1} sx={{ width: { md: "50%", xs: "100%" } }}>
+    <Field name="maxUsagePerOrder" component={TextField} type="number" label="Max # uses per Order"/>
+    <Field name="maxUsagePerCustomer" component={TextField} type="number" label="Max # uses per Customer"/>
+  </Stack>
+);

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -12,7 +12,7 @@ import { client } from "@graphql/graphql-request-client";
 import { useShop } from "@containers/ShopProvider";
 import { PromotionState, useCreatePromotionMutation, useGetPromotionQuery, useUpdatePromotionMutation } from "@graphql/generates";
 import { PROMOTION_STACKABILITY_OPTIONS, PROMOTION_TYPE_OPTIONS } from "../constants";
-import { Promotion, PromotionType, Trigger } from "types/promotions";
+import { Action, Promotion, PromotionType, Trigger } from "types/promotions";
 import { useGlobalBreadcrumbs } from "@hooks/useGlobalBreadcrumbs";
 import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
@@ -33,7 +33,7 @@ type PromotionFormValue = {
   name: string
   description: string
   promotionType: PromotionType
-  actions: Promotion["actions"]
+  actions: Action[]
   triggers: Promotion["triggers"]
   stackability: Promotion["stackability"]
   label: string
@@ -62,6 +62,16 @@ const normalizeFormValues = (values: PromotionFormValue) =>
     triggers: normalizeTriggersData(values.triggers),
     actions: normalizeActionsData(values.actions)
   });
+
+const formatActions = (actions: Action[]): Action[] => actions.map((action) =>
+  ({
+    ...action,
+    actionParameters: {
+      ...action.actionParameters,
+      discountMaxUnits: action.actionParameters?.discountMaxUnits || 0,
+      discountMaxValue: action.actionParameters?.discountMaxValue || 0
+    }
+  }));
 
 const PromotionDetails = () => {
   const { promotionId } = useParams();
@@ -127,7 +137,7 @@ const PromotionDetails = () => {
     name: data?.promotion?.name || "",
     description: data?.promotion?.description || "",
     promotionType: (data?.promotion?.promotionType || "order-discount") as PromotionType,
-    actions: data?.promotion?.actions || [],
+    actions: data?.promotion?.actions ? formatActions(data.promotion.actions) : [],
     triggers: data?.promotion?.triggers ? formatTriggers(
       data.promotion.triggers,
       data?.promotion?.name || "trigger name"

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -29,6 +29,8 @@ export const promotionSchema = Yup.object().shape({
           then: (schema) => schema.notRequired(),
           otherwise: (schema) => schema.required("This field is required").moreThan(0, "Discount value must be greater than 0")
         }),
+      discountMaxUnits: Yup.number().min(0, "This field must be greater than or equal to 0"),
+      discountMaxValue: Yup.number().min(0, "This field must be greater than or equal to 0"),
       discountCalculationType: Yup.string().required("This field is required"),
       discountType: Yup.string().required(),
       inclusionRules: Yup.object().when("discountType", {
@@ -76,8 +78,5 @@ export const promotionSchema = Yup.object().shape({
     })
   })).min(1, "Promotion should have at least 1 trigger"),
   startDate: Yup.date().nullable().required("This field is required"),
-  endDate: Yup.date().nullable().min(Yup.ref("startDate"), "End date should be after start date"),
-  maxUsagePerOrder: Yup.number().moreThan(0, "This field must be greater than 0"),
-  maxDiscountPerOrder: Yup.number().moreThan(0, "This field must be greater than 0"),
-  maxUsagePerCustomer: Yup.number().moreThan(0, "This field must be greater than 0")
+  endDate: Yup.date().nullable().min(Yup.ref("startDate"), "End date should be after start date")
 });

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -78,5 +78,6 @@ export const promotionSchema = Yup.object().shape({
   startDate: Yup.date().nullable().required("This field is required"),
   endDate: Yup.date().nullable().min(Yup.ref("startDate"), "End date should be after start date"),
   maxUsagePerOrder: Yup.number().moreThan(0, "This field must be greater than 0"),
+  maxDiscountPerOrder: Yup.number().moreThan(0, "This field must be greater than 0"),
   maxUsagePerCustomer: Yup.number().moreThan(0, "This field must be greater than 0")
 });

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -76,5 +76,7 @@ export const promotionSchema = Yup.object().shape({
     })
   })).min(1, "Promotion should have at least 1 trigger"),
   startDate: Yup.date().nullable().required("This field is required"),
-  endDate: Yup.date().nullable().min(Yup.ref("startDate"), "End date should be after start date")
+  endDate: Yup.date().nullable().min(Yup.ref("startDate"), "End date should be after start date"),
+  maxUsagePerOrder: Yup.number().moreThan(0, "This field must be greater than 0"),
+  maxUsagePerCustomer: Yup.number().moreThan(0, "This field must be greater than 0")
 });

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -22,7 +22,8 @@ export enum TriggerType {
 
 export enum Stackability {
   None = "none",
-  All = "all"
+  All = "all",
+  Any = "any"
 }
 
 export type RuleCondition = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -58,12 +58,14 @@ export type Trigger = {
 
 export type Action = {
   actionKey: string
-  actionParameters?: {
+  actionParameters: {
     discountType: string
     discountValue: number
     discountCalculationType: CalculationType
     inclusionRules?: Rule
     exclusionRules?: Rule
+    discountMaxValue?: number
+    discountMaxUnits?: number
   }
 }
 export interface Promotion extends Omit<APIPromotion, "__typename" | "actions" | "promotionType" | "triggers"> {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -22,8 +22,7 @@ export enum TriggerType {
 
 export enum Stackability {
   None = "none",
-  All = "all",
-  Any = "any"
+  All = "all"
 }
 
 export type RuleCondition = {


### PR DESCRIPTION
Resolves #149, #150

Testing Instructions:
- Use branch feat/promotions on API to test this feature
- Start the app and login with a valid account
- Navigate to Promotions
- Click on 1 promotion row to navigate to Promotion details page
- Scroll down to Actions section
<img width="1232" alt="image" src="https://user-images.githubusercontent.com/33818318/211973703-7e5131b9-9ef1-487f-86a5-0af83187394f.png">
