### PR TITLE
As an operator I want to Trigger a promotion based on an Item in the cart

### DIFF
--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -115,4 +115,27 @@ describe("Promotion Details", () => {
       expect(screen.getByLabelText("Promotion Name")).toHaveValue(enabledPromotions[0].name);
     });
   }, 50000);
+
+  it("should change trigger value field based on trigger type", async () => {
+    renderWithProviders(
+      <Routes>
+        <Route element={<AppLayout/>}>
+          <Route path="promotions/:promotionId" element={
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <PromotionDetails/>
+            </LocalizationProvider>}/>
+        </Route>
+      </Routes>
+      , { initialEntries: [`/promotions/${promotion._id}`] }
+    );
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar", { hidden: true }), { timeout: 3000 });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Add Trigger"));
+    expect(screen.getByText("Cart Value is greater than")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Trigger Value"), "12");
+
+    await user.click(screen.getByLabelText("Select Trigger Type"));
+    await user.click(within(screen.getByRole("listbox")).getByText("Item is in cart"));
+    expect(screen.getByText("Minimum number of items required to trigger promotion")).toBeInTheDocument();
+  }, 50000);
 });

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -31,7 +31,7 @@ describe("Promotion Details", () => {
     expect(screen.getAllByText("Order Discount")).toHaveLength(2);
     expect(screen.getByText("% Off")).toBeInTheDocument();
     expect(screen.queryByText("Add Action")).not.toBeInTheDocument();
-    expect(screen.queryByText("Add Trigger")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add Trigger" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Discount Value")).toHaveValue(promotion.actions[0].actionParameters?.discountValue);
     expect(screen.getByLabelText("Stack with Any")).toBeInTheDocument();
     expect(screen.getByLabelText("Available From")).toHaveValue(format(promotion.startDate, DATE_FORMAT));
@@ -130,7 +130,6 @@ describe("Promotion Details", () => {
     );
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar", { hidden: true }), { timeout: 3000 });
     const user = userEvent.setup();
-    await user.click(screen.getByText("Add Trigger"));
     expect(screen.getByText("Cart Value is greater than")).toBeInTheDocument();
     await user.type(screen.getByLabelText("Trigger Value"), "12");
 

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -41,6 +41,7 @@ export const PromotionTriggers = () => {
                             component={SelectField}
                             hiddenLabel
                             label="Select Trigger Type"
+                            ariaLabel="Select Trigger Type"
                             options={TRIGGER_TYPE_OPTIONS}
                             autoWidth
                           />

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -1,4 +1,3 @@
-import InputAdornment from "@mui/material/InputAdornment";
 import Stack from "@mui/material/Stack";
 import { Field, FieldArray } from "formik";
 import Grid from "@mui/material/Grid";
@@ -9,18 +8,19 @@ import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined
 import { useState } from "react";
 import Alert from "@mui/material/Alert";
 
-import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
 import { TRIGGER_TYPE_OPTIONS } from "../constants";
 import { AlertDialog } from "@components/Dialog";
 import { Trigger } from "types/promotions";
 
 import { EligibleItems } from "./EligibleItems";
+import { TriggerValuesField } from "./TriggerValuesField";
 
 
 export const PromotionTriggers = () => {
   const [activeField, setActiveField] = useState<number>();
   const handleClose = () => setActiveField(undefined);
+
   return (
     <Stack direction="column" mt={2} gap={2}>
       <FieldArray
@@ -45,20 +45,7 @@ export const PromotionTriggers = () => {
                             autoWidth
                           />
                         </Grid>
-                        <Grid item>
-                          <Field
-                            component={TextField}
-                            name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
-                            label="Value"
-                            ariaLabel="Trigger Value"
-                            type="number"
-                            hiddenLabel
-                            startAdornment={
-                              <InputAdornment position="start">$</InputAdornment>
-                            }
-                            sx={{ width: "100px" }}
-                          />
-                        </Grid>
+                        <TriggerValuesField trigger={values.triggers[index]} index={index}/>
                       </Grid>
                     }
                   />

--- a/src/pages/Promotions/Details/TriggerValuesField.tsx
+++ b/src/pages/Promotions/Details/TriggerValuesField.tsx
@@ -35,6 +35,7 @@ export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) 
       endAdornment={
         <InputAdornment position="end">items</InputAdornment>
       }
+      helperText="Minimum number of items required to trigger promotion"
       sx={{ width: "130px" }}
     />
   };

--- a/src/pages/Promotions/Details/TriggerValuesField.tsx
+++ b/src/pages/Promotions/Details/TriggerValuesField.tsx
@@ -1,0 +1,47 @@
+import Grid from "@mui/material/Grid";
+import InputAdornment from "@mui/material/InputAdornment";
+import { Field } from "formik";
+
+import { TextField } from "@components/TextField";
+import { Trigger, TriggerType } from "types/promotions";
+
+type TriggerValuesFieldProps = {
+  trigger: Trigger
+  index: number
+}
+export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) => {
+  const triggerType = trigger.triggerParameters?.conditions.all?.[0].triggerType?.split("-")[0];
+
+  const fieldComponentMap: Record<string, JSX.Element> = {
+    [TriggerType.ItemAmount]: <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
+      label="Value"
+      ariaLabel="Trigger Value"
+      type="number"
+      hiddenLabel
+      startAdornment={
+        <InputAdornment position="start">$</InputAdornment>
+      }
+      sx={{ width: "100px" }}
+    />,
+    [TriggerType.ItemCount]: <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
+      label="Number of items required in cart"
+      ariaLabel="Number of items required in cart"
+      type="number"
+      hiddenLabel
+      endAdornment={
+        <InputAdornment position="end">items</InputAdornment>
+      }
+      sx={{ width: "130px" }}
+    />
+  };
+
+  return triggerType ?
+    (
+      <Grid item>{fieldComponentMap[triggerType]}</Grid>
+    )
+    : null;
+};

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -15,7 +15,10 @@ export const normalizeTriggersData = (triggers?: Trigger[]) => triggers?.map((tr
     ...trigger.triggerParameters,
     inclusionRules: normalizeRule(trigger.triggerParameters?.inclusionRules),
     exclusionRules: normalizeRule(trigger.triggerParameters?.exclusionRules),
-    conditions: { all: trigger.triggerParameters?.conditions.all.map(({ triggerType, ...condition }) => condition) }
+    conditions: {
+      all: trigger.triggerParameters?.conditions.all
+        .map(({ triggerType, value }) => ({ fact: triggerType?.split("-")[0], operator: triggerType?.split("-")[1], value }))
+    }
   }
 }));
 

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -58,7 +58,7 @@ export const promotionSchema = Yup.object().shape({
     triggerParameters: Yup.object({
       conditions: Yup.object({
         all: Yup.array().of(Yup.object({
-          value: Yup.number().moreThan(0, "Cart value must be greater than 0").required("This field is required")
+          value: Yup.number().moreThan(0, "This field must be greater than 0").required("This field is required")
         }))
       }),
       inclusionRules: Yup.object({

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -3,7 +3,11 @@ import * as Yup from "yup";
 const ruleSchema = Yup.object({
   path: Yup.string().required("This field is required"),
   operator: Yup.string().required("This field is required"),
-  value: Yup.array().min(1, "This field must have at least 1 item")
+  value: Yup.array().min(1, "This field must have at least 1 value").when("operator", {
+    is: "equal",
+    then: (schema) => schema.length(1, "Change the operator to \"Is Any Of\" to add multiple values"),
+    otherwise: (schema) => schema
+  })
 });
 
 const shippingRuleSchema = Yup.object({ value: Yup.array().min(1, "This field must have at least 1 item") });

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -27,7 +27,8 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
 ];
 
 export const TRIGGER_TYPE_OPTIONS = [
-  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" }
+  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
+  { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
 ];
 
 

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -28,7 +28,7 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
 
 export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType> = {
   totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
-  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
+  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanInclusive" }
 };
 
 export const TRIGGER_TYPE_OPTIONS = Object.values(TRIGGER_TYPE_MAP);

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -1,5 +1,5 @@
 import { SelectOptionType } from "types/common";
-import { CalculationType, PromotionType, Stackability } from "types/promotions";
+import { CalculationType, PromotionType, Stackability, TriggerType } from "types/promotions";
 
 export const CALCULATION_TYPE_OPTIONS: Record<CalculationType, SelectOptionType<CalculationType> & {symbol?: string}> = {
   percentage: { label: "% Off", value: CalculationType.Percentage, symbol: "%" },
@@ -26,10 +26,12 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
   { label: "Stack with Any", value: Stackability.All }
 ];
 
-export const TRIGGER_TYPE_OPTIONS = [
-  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
-  { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
-];
+export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType> = {
+  totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
+  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
+};
+
+export const TRIGGER_TYPE_OPTIONS = Object.values(TRIGGER_TYPE_MAP);
 
 
 export const OPERATOR_OPTIONS: SelectOptionType[] = [

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -15,6 +15,11 @@ export enum CalculationType {
   Flat = "flat"
 }
 
+export enum TriggerType {
+  ItemAmount = "totalItemAmount",
+  ItemCount = "totalItemCount"
+}
+
 export enum Stackability {
   None = "none",
   All = "all"


### PR DESCRIPTION
Resolves #138 

Testing Instructions:
- Use branch feat/promotions on API to test this feature
- Start the app and login with a valid account
- Navigate to Promotions
- Click on 1 promotion row to navigate to Promotion details page
- Scroll down to Triggers section and change option to `Item is in cart`

<img width="2237" alt="Screenshot 2023-01-12 at 08 51 48" src="https://user-images.githubusercontent.com/33818318/211956966-190eeca9-bc1d-4952-b6c6-8e63592c5002.png">

<img width="2254" alt="Screenshot 2023-01-12 at 08 51 53" src="https://user-images.githubusercontent.com/33818318/211956958-ad8f7e63-7b71-4b77-98be-3c988511c891.png">

