### PR TITLE
Promotion Coupons

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -6,7 +6,6 @@ import FormLabel from "@mui/material/FormLabel";
 import Collapse from "@mui/material/Collapse";
 import { uniqueId } from "lodash-es";
 import { forwardRef, useRef } from "react";
-import { Typography } from "@mui/material";
 
 type CustomTextFieldProps = {
   helperText?: string
@@ -56,7 +55,7 @@ export const TextField = forwardRef(({
       variant="standard"
     >
       {!hiddenLabel && (
-        <FormLabel htmlFor={fieldId} component={Typography} noWrap>
+        <FormLabel htmlFor={fieldId}>
           {label}
         </FormLabel>
       )}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -19,7 +19,7 @@ export type TextFieldProps = FieldProps &
   CustomTextFieldProps
 
 export const TextField = forwardRef(({
-  field: { onBlur: fieldOnBlur, ...restFieldProps },
+  field: { onBlur: fieldOnBlur, onChange: fieldOnChange, ...restFieldProps },
   form: { isSubmitting, touched, errors },
   fullWidth = true,
   size = "small",
@@ -30,6 +30,7 @@ export const TextField = forwardRef(({
   helperText,
   hiddenLabel,
   ariaLabel,
+  onChange,
   ...props
 }: TextFieldProps, ref) => {
   const fieldError = getIn(errors, restFieldProps.name) as string;
@@ -41,6 +42,8 @@ export const TextField = forwardRef(({
   const helperTextId = useRef(uniqueId("helper-text")).current;
 
   const _onBlur = onBlur ?? ((event) => fieldOnBlur(event ?? restFieldProps.name));
+
+  const _onChange = onChange ?? fieldOnChange;
 
   return (
     <FormControl
@@ -63,6 +66,7 @@ export const TextField = forwardRef(({
         aria-describedby={helperTextId}
         inputProps={{ "aria-label": ariaLabel }}
         ref={ref}
+        onChange={_onChange}
         {...props}
         {...restFieldProps}
       />

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -6,6 +6,7 @@ import FormLabel from "@mui/material/FormLabel";
 import Collapse from "@mui/material/Collapse";
 import { uniqueId } from "lodash-es";
 import { forwardRef, useRef } from "react";
+import { Typography } from "@mui/material";
 
 type CustomTextFieldProps = {
   helperText?: string
@@ -52,7 +53,7 @@ export const TextField = forwardRef(({
       variant="standard"
     >
       {!hiddenLabel && (
-        <FormLabel htmlFor={fieldId}>
+        <FormLabel htmlFor={fieldId} component={Typography} noWrap>
           {label}
         </FormLabel>
       )}

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -27,8 +27,8 @@ export const Toast = ({ message, autoHideDuration, onExited, ...rest }: ToastPro
   };
 
   return (
-    <Snackbar key={message.key} open={open} autoHideDuration={autoHideDuration || 5000} onClose={handleClose} TransitionProps={{ onExited }} {...rest}>
-      <Alert severity={message.severity} sx={{ width: "100%" }} variant="filled">
+    <Snackbar key={message.key} open={open} autoHideDuration={autoHideDuration || 6000} onClose={handleClose} TransitionProps={{ onExited }} {...rest}>
+      <Alert onClose={handleClose} severity={message.severity} sx={{ width: "100%" }} variant="filled">
         {message.message}
       </Alert>
     </Snackbar>

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -150,6 +150,25 @@ export enum AccountSortByField {
   UpdatedAt = 'updatedAt'
 }
 
+/** Input for the `acknowledgeCartMessage` mutation call */
+export type AcknowledgeCartMessageInput = {
+  /** The cart ID */
+  cartId: Scalars['ID'];
+  /** The cart anonymous token */
+  cartToken?: InputMaybe<Scalars['String']>;
+  /** An optional string identifying the mutation call, which will be returned in the response payload */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The message to acknowledge */
+  messageId: Scalars['String'];
+};
+
+/** The payload returned from the `acknowledgeCartMessage` mutation call */
+export type AcknowledgeCartMessagePayload = {
+  __typename?: 'AcknowledgeCartMessagePayload';
+  /** The modified cart */
+  cart: Cart;
+};
+
 /** The action to be taken when a promotion is triggered */
 export type Action = {
   __typename?: 'Action';
@@ -582,11 +601,11 @@ export type ApplyCouponToCartInput = {
   accountId?: InputMaybe<Scalars['ID']>;
   /** The ID of the Cart */
   cartId: Scalars['ID'];
+  /** Cart token, if anonymous */
+  cartToken?: InputMaybe<Scalars['String']>;
   /** The coupon code to apply */
   couponCode: Scalars['String'];
   shopId: Scalars['ID'];
-  /** Cart token, if anonymous */
-  token?: InputMaybe<Scalars['String']>;
 };
 
 /** The response for the applyCouponToCart mutation */
@@ -840,6 +859,8 @@ export type Cart = Node & {
   expiresAt?: Maybe<Scalars['DateTime']>;
   /** The items that have been added to the cart. A cart is not created until the first item is added. Items can be removed from a cart, and a cart is not deleted if all items are removed from it. Because all items may have been removed, this may be an empty array. */
   items?: Maybe<CartItemConnection>;
+  /** The cart messages. These are messages that are returned from the server and displayed to the user. */
+  messages?: Maybe<Array<Maybe<CartMessage>>>;
   /**
    * If any products or variants become hidden or are deleted after they were added to this cart, they'll be
    * automatically moved from `items` to `missingItems`. Clients may want to use this to show an
@@ -942,6 +963,8 @@ export type CartItem = Node & {
   parcel?: Maybe<ShippingParcel>;
   /** The current price of the item */
   price: Money;
+  /** The price type of the product */
+  priceType?: Maybe<PriceType>;
   /** The price at which this item was listed when it was added to the cart */
   priceWhenAdded: Money;
   /** The product and chosen options */
@@ -1050,6 +1073,36 @@ export enum CartItemsSortByField {
   Id = '_id',
   /** Date and time at which the item was added to the cart */
   AddedAt = 'addedAt'
+}
+
+/** The cart message type */
+export type CartMessage = {
+  __typename?: 'CartMessage';
+  /** Cart message ID */
+  _id: Scalars['ID'];
+  /** Cart message is acknowledged */
+  acknowledged?: Maybe<Scalars['Boolean']>;
+  /** Cart message content */
+  message?: Maybe<Scalars['String']>;
+  /** Cart message meta fields */
+  metaFields?: Maybe<Scalars['JSONObject']>;
+  /** The cart message should be confirm by user or not */
+  requiresReadAcknowledgement?: Maybe<Scalars['Boolean']>;
+  /** Cart message severity */
+  severity: CartMessageSeverity;
+  /** Cart message subject */
+  subject?: Maybe<Scalars['String']>;
+  /** Cart message title */
+  title: Scalars['String'];
+};
+
+export enum CartMessageSeverity {
+  /** Error message */
+  Error = 'error',
+  /** Informational message */
+  Info = 'info',
+  /** Warning message */
+  Warning = 'warning'
 }
 
 /** Supported cart reconciliation modes */
@@ -1432,6 +1485,8 @@ export type CatalogProductVariant = CatalogProductOrVariant & Node & {
   options?: Maybe<Array<Maybe<CatalogProductVariant>>>;
   /** The country of origin */
   originCountry?: Maybe<Scalars['String']>;
+  /** The type of price for this variant */
+  priceType?: Maybe<PriceType>;
   /** Price and related information, per currency */
   pricing: Array<Maybe<ProductPricingInfo>>;
   /** The primary image of this variant / option */
@@ -1502,6 +1557,84 @@ export type CloneProductsPayload = {
   clientMutationId?: Maybe<Scalars['String']>;
   /** Array of newly cloned products */
   products: Array<Maybe<Product>>;
+};
+
+/** Filter with One level of conditions (use either 'any' or 'all' not both) */
+export type ConditionsArray = {
+  /** Array of single-conditions */
+  all?: InputMaybe<Array<InputMaybe<SingleConditionInput>>>;
+  /** Array of single-conditions */
+  any?: InputMaybe<Array<InputMaybe<SingleConditionInput>>>;
+};
+
+export type Coupon = {
+  __typename?: 'Coupon';
+  /** The coupon ID */
+  _id: Scalars['ID'];
+  /** The promotion can be used in the store */
+  canUseInStore?: Maybe<Scalars['Boolean']>;
+  /** The coupon code */
+  code: Scalars['String'];
+  /** Coupon created time */
+  createdAt: Scalars['Date'];
+  /** The number of times this coupon can be used */
+  maxUsageTimes?: Maybe<Scalars['Int']>;
+  /** The number of times this coupon can be used per user */
+  maxUsageTimesPerUser?: Maybe<Scalars['Int']>;
+  /** The coupon name */
+  name: Scalars['String'];
+  /** The promotion ID */
+  promotionId: Scalars['ID'];
+  /** The shop ID */
+  shopId: Scalars['ID'];
+  /** Coupon updated time */
+  updatedAt: Scalars['Date'];
+  /** The number of times this coupon has been used */
+  usedCount?: Maybe<Scalars['Int']>;
+  /** The coupon owner ID */
+  userId?: Maybe<Scalars['ID']>;
+};
+
+export type CouponConnection = {
+  __typename?: 'CouponConnection';
+  /** The list of nodes that match the query, wrapped in an edge to provide a cursor string for each */
+  edges?: Maybe<Array<Maybe<CouponEdge>>>;
+  /**
+   * You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+   * if you know you will not need to paginate the results.
+   */
+  nodes?: Maybe<Array<Maybe<Coupon>>>;
+  /** Information to help a client request the next or previous page */
+  pageInfo: PageInfo;
+  /** The total number of nodes that match your query */
+  totalCount: Scalars['Int'];
+};
+
+/** A connection edge in which each node is a `Coupon` object */
+export type CouponEdge = {
+  __typename?: 'CouponEdge';
+  /** The cursor that represents this node in the paginated results */
+  cursor: Scalars['ConnectionCursor'];
+  /** The coupon node */
+  node?: Maybe<Coupon>;
+};
+
+export type CouponFilter = {
+  /** The coupon code */
+  code?: InputMaybe<Scalars['String']>;
+  /** The expiration date of the coupon */
+  expirationDate?: InputMaybe<Scalars['Date']>;
+  /** The related promotion ID */
+  promotionId?: InputMaybe<Scalars['ID']>;
+  /** The coupon name */
+  userId?: InputMaybe<Scalars['ID']>;
+};
+
+export type CouponQueryInput = {
+  /** The unique ID of the coupon */
+  _id: Scalars['String'];
+  /** The unique ID of the shop */
+  shopId: Scalars['String'];
 };
 
 /** The details for creating a group */
@@ -1824,6 +1957,24 @@ export type CreateShopPayload = {
   clientMutationId?: Maybe<Scalars['String']>;
   /** The shop which was created */
   shop: Shop;
+};
+
+/** The input for the createStandardCoupon mutation */
+export type CreateStandardCouponInput = {
+  /** Can use this coupon in the store */
+  canUseInStore: Scalars['Boolean'];
+  /** The coupon code */
+  code: Scalars['String'];
+  /** The number of times this coupon can be used */
+  maxUsageTimes?: InputMaybe<Scalars['Int']>;
+  /** The number of times this coupon can be used per user */
+  maxUsageTimesPerUser?: InputMaybe<Scalars['Int']>;
+  /** The coupon name */
+  name: Scalars['String'];
+  /** The promotion ID */
+  promotionId: Scalars['ID'];
+  /** The shop ID */
+  shopId: Scalars['ID'];
 };
 
 /** Input for the createStripePaymentIntent mutation */
@@ -2499,6 +2650,14 @@ export type FakeData = {
   __typename?: 'FakeData';
   /** Do not use this */
   doNotUse?: Maybe<Scalars['String']>;
+};
+
+/** Filter with nested conditions of input (use either 'any' or 'all' not both) */
+export type FilterConditionsInput = {
+  /** Array holding Nested conditions (use either 'any' or 'all' not both) */
+  all?: InputMaybe<Array<InputMaybe<ConditionsArray>>>;
+  /** Array holding Nested conditions (use either 'any' or 'all' not both) */
+  any?: InputMaybe<Array<InputMaybe<ConditionsArray>>>;
 };
 
 /** Defines a fulfillment method that has a fixed price. This type is provided by the `flat-rate` fulfillment plugin. */
@@ -3185,6 +3344,8 @@ export type MoveOrderItemsPayload = {
 /** Mutations have side effects, such as mutating data or triggering a task */
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Acknowledge a message on the account cart */
+  acknowledgeCartMessage: AcknowledgeCartMessagePayload;
   /** Add a new address to the `addressBook` field for an account */
   addAccountAddressBookEntry?: Maybe<AddAccountAddressBookEntryPayload>;
   /** Add an email address to an account */
@@ -3265,6 +3426,8 @@ export type Mutation = {
   createRefund: CreateRefundPayload;
   /** Create a new shop */
   createShop: CreateShopPayload;
+  /** Create a standard coupon mutation */
+  createStandardCoupon?: Maybe<StandardCouponPayload>;
   /** Create Stripe payment intent for the current cart and return a token */
   createStripePaymentIntent: CreateStripePaymentIntentPayload;
   /** Create a surcharge */
@@ -3331,6 +3494,8 @@ export type Mutation = {
   removeAccountGroup?: Maybe<RemoveAccountGroupPayload>;
   /** Remove item(s) from a cart */
   removeCartItems: RemoveCartItemsPayload;
+  /** Remove a coupon from a cart */
+  removeCouponFromCart?: Maybe<RemoveCouponFromCartPayload>;
   /** Remove a discount code from a cart */
   removeDiscountCodeFromCart: RemoveDiscountCodeFromCartPayload;
   /** Removes an existing tag */
@@ -3439,6 +3604,12 @@ export type Mutation = {
   verifyEmail?: Maybe<Scalars['Boolean']>;
   /** Use this mutation to verify the SMTP email settings */
   verifySMTPEmailSettings: VerifySmtpEmailSettingsInputPayload;
+};
+
+
+/** Mutations have side effects, such as mutating data or triggering a task */
+export type MutationAcknowledgeCartMessageArgs = {
+  input: AcknowledgeCartMessageInput;
 };
 
 
@@ -3661,6 +3832,12 @@ export type MutationCreateShopArgs = {
 
 
 /** Mutations have side effects, such as mutating data or triggering a task */
+export type MutationCreateStandardCouponArgs = {
+  input?: InputMaybe<CreateStandardCouponInput>;
+};
+
+
+/** Mutations have side effects, such as mutating data or triggering a task */
 export type MutationCreateStripePaymentIntentArgs = {
   input: CreateStripePaymentIntentInput;
 };
@@ -3845,6 +4022,12 @@ export type MutationRemoveAccountGroupArgs = {
 /** Mutations have side effects, such as mutating data or triggering a task */
 export type MutationRemoveCartItemsArgs = {
   input: RemoveCartItemsInput;
+};
+
+
+/** Mutations have side effects, such as mutating data or triggering a task */
+export type MutationRemoveCouponFromCartArgs = {
+  input?: InputMaybe<RemoveCouponFromCartInput>;
 };
 
 
@@ -4996,6 +5179,15 @@ export type Plugin = {
   version?: Maybe<Scalars['String']>;
 };
 
+export enum PriceType {
+  /** The price that was permanently marked down to move */
+  Clearance = 'clearance',
+  /** The full price of the product */
+  Full = 'full',
+  /** Temporarily on sale (e.g. Black Friday or Mother's Day sale) but return to full price */
+  Sale = 'sale'
+}
+
 /** A Reaction product */
 export type Product = {
   __typename?: 'Product';
@@ -5334,6 +5526,8 @@ export type ProductVariant = {
    * @deprecated Use `pricing`
    */
   price?: Maybe<Scalars['Float']>;
+  /** The type of price for this variant */
+  priceType?: Maybe<PriceType>;
   /** Pricing information */
   pricing: ProductPricingInfo;
   /** The shop to which this product variant belongs */
@@ -5407,6 +5601,8 @@ export type ProductVariantInput = {
   originCountry?: InputMaybe<Scalars['String']>;
   /** Variant price. DEPRECATED. Use the `updateProductVariantPrices` mutation to set product variant prices. */
   price?: InputMaybe<Scalars['Float']>;
+  /** The type of price for product variant */
+  priceType?: InputMaybe<PriceType>;
   /** SKU of variant */
   sku?: InputMaybe<Scalars['String']>;
   /** Tax code */
@@ -5446,6 +5642,8 @@ export type Promotion = {
   _id: Scalars['String'];
   /** The actions to be taken when the promotion is triggered */
   actions?: Maybe<Array<Action>>;
+  /** The coupon code */
+  coupon?: Maybe<Coupon>;
   /** When was this record created */
   createdAt: Scalars['Date'];
   /** A longer detailed description of the promotion */
@@ -5453,7 +5651,7 @@ export type Promotion = {
   /** Whether the promotion is current active */
   enabled: Scalars['Boolean'];
   /** The date that the promotion end (empty means it never ends) */
-  endDate?: Maybe<Scalars['Date']>;
+  endDate?: Maybe<Scalars['DateTime']>;
   /** The short description of the promotion */
   label: Scalars['String'];
   /** The short description of the promotion */
@@ -5467,7 +5665,7 @@ export type Promotion = {
   /** Definition of how this promotion can be combined (none, per-type, or all) */
   stackability?: Maybe<Stackability>;
   /** The date that the promotion begins */
-  startDate: Scalars['Date'];
+  startDate: Scalars['DateTime'];
   /** What is the current state of the promotion */
   state: PromotionState;
   /** What type of trigger this promotion uses */
@@ -5501,7 +5699,7 @@ export type PromotionCreateInput = {
   /** Whether the promotion is current active */
   enabled: Scalars['Boolean'];
   /** The date that the promotion end (empty means it never ends) */
-  endDate?: InputMaybe<Scalars['Date']>;
+  endDate?: InputMaybe<Scalars['DateTime']>;
   /** The short description of the promotion visible to the customer */
   label: Scalars['String'];
   /** The short description of the promotion */
@@ -5513,7 +5711,7 @@ export type PromotionCreateInput = {
   /** Definition of how this promotion can be combined (none, per-type, or all) */
   stackability?: InputMaybe<StackabilityInput>;
   /** The date that the promotion begins */
-  startDate: Scalars['Date'];
+  startDate: Scalars['DateTime'];
   /** The triggers for this Promotion */
   triggers?: InputMaybe<Array<TriggerInput>>;
 };
@@ -5575,7 +5773,7 @@ export type PromotionUpdateInput = {
   /** Whether the promotion is current active */
   enabled: Scalars['Boolean'];
   /** The date that the promotion end (empty means it never ends) */
-  endDate?: InputMaybe<Scalars['Date']>;
+  endDate?: InputMaybe<Scalars['DateTime']>;
   /** The short description of the promotion visible to the customer */
   label: Scalars['String'];
   /** The short description of the promotion */
@@ -5587,7 +5785,7 @@ export type PromotionUpdateInput = {
   /** Definition of how this promotion can be combined (none, per-type, or all) */
   stackability?: InputMaybe<StackabilityInput>;
   /** The date that the promotion begins */
-  startDate: Scalars['Date'];
+  startDate: Scalars['DateTime'];
   /** What is the current state of the promotion */
   state?: InputMaybe<PromotionState>;
   /** What type of trigger this uses */
@@ -5654,6 +5852,10 @@ export type Query = {
   catalogItemProduct?: Maybe<CatalogItemProduct>;
   /** Gets items from a shop catalog */
   catalogItems?: Maybe<CatalogItemConnection>;
+  /** Get a coupon */
+  coupon?: Maybe<Coupon>;
+  /** Get list of coupons */
+  coupons?: Maybe<CouponConnection>;
   /** Returns customer accounts */
   customers: AccountConnection;
   /** Gets discount codes */
@@ -5662,6 +5864,14 @@ export type Query = {
   emailJobs: EmailJobConnection;
   /** Retrieves a list of email templates */
   emailTemplates?: Maybe<TemplateConnection>;
+  /** Query to get a filtered list of Accounts */
+  filterAccounts?: Maybe<AccountConnection>;
+  /** Query to get a filtered list of Customers */
+  filterCustomers?: Maybe<AccountConnection>;
+  /** Query to get a filtered list of Orders */
+  filterOrders?: Maybe<OrderConnection>;
+  /** Query to get a filtered list of Products */
+  filterProducts?: Maybe<ProductConnection>;
   /** Get a flat rate fulfillment method */
   flatRateFulfillmentMethod: FlatRateFulfillmentMethod;
   /** Get a flat rate fulfillment methods */
@@ -5843,6 +6053,26 @@ export type QueryCatalogItemsArgs = {
 
 
 /** Queries return all requested data, without any side effects */
+export type QueryCouponArgs = {
+  input?: InputMaybe<CouponQueryInput>;
+};
+
+
+/** Queries return all requested data, without any side effects */
+export type QueryCouponsArgs = {
+  after?: InputMaybe<Scalars['ConnectionCursor']>;
+  before?: InputMaybe<Scalars['ConnectionCursor']>;
+  filter?: InputMaybe<CouponFilter>;
+  first?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  last?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  shopId: Scalars['ID'];
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortOrder?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Queries return all requested data, without any side effects */
 export type QueryCustomersArgs = {
   after?: InputMaybe<Scalars['ConnectionCursor']>;
   before?: InputMaybe<Scalars['ConnectionCursor']>;
@@ -5885,6 +6115,62 @@ export type QueryEmailTemplatesArgs = {
   last?: InputMaybe<Scalars['ConnectionLimitInt']>;
   offset?: InputMaybe<Scalars['Int']>;
   shopId: Scalars['ID'];
+};
+
+
+/** Queries return all requested data, without any side effects */
+export type QueryFilterAccountsArgs = {
+  after?: InputMaybe<Scalars['ConnectionCursor']>;
+  before?: InputMaybe<Scalars['ConnectionCursor']>;
+  conditions?: InputMaybe<FilterConditionsInput>;
+  first?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  last?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  shopId: Scalars['ID'];
+  sortBy?: InputMaybe<AccountSortByField>;
+  sortOrder?: InputMaybe<SortOrder>;
+};
+
+
+/** Queries return all requested data, without any side effects */
+export type QueryFilterCustomersArgs = {
+  after?: InputMaybe<Scalars['ConnectionCursor']>;
+  before?: InputMaybe<Scalars['ConnectionCursor']>;
+  conditions?: InputMaybe<FilterConditionsInput>;
+  first?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  last?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  shopId: Scalars['ID'];
+  sortBy?: InputMaybe<AccountSortByField>;
+  sortOrder?: InputMaybe<SortOrder>;
+};
+
+
+/** Queries return all requested data, without any side effects */
+export type QueryFilterOrdersArgs = {
+  after?: InputMaybe<Scalars['ConnectionCursor']>;
+  before?: InputMaybe<Scalars['ConnectionCursor']>;
+  conditions?: InputMaybe<FilterConditionsInput>;
+  first?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  last?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  shopId: Scalars['ID'];
+  sortBy?: InputMaybe<OrdersSortByField>;
+  sortOrder?: InputMaybe<SortOrder>;
+};
+
+
+/** Queries return all requested data, without any side effects */
+export type QueryFilterProductsArgs = {
+  after?: InputMaybe<Scalars['ConnectionCursor']>;
+  before?: InputMaybe<Scalars['ConnectionCursor']>;
+  conditions?: InputMaybe<FilterConditionsInput>;
+  first?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  last?: InputMaybe<Scalars['ConnectionLimitInt']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  shopId: Scalars['ID'];
+  sortBy?: InputMaybe<ProductSortByField>;
+  sortOrder?: InputMaybe<SortOrder>;
 };
 
 
@@ -6332,6 +6618,32 @@ export type Refund = Node & {
   reason?: Maybe<Scalars['String']>;
 };
 
+/** Relational Operator Types used in filtering inside a single condition */
+export enum RelationalOperatorTypes {
+  /** Begins With used with String types to filter based on the beginning of the string */
+  BeginsWith = 'beginsWith',
+  /** Ends With used with String types to filter based on the end of the string */
+  EndsWith = 'endsWith',
+  /** Equal to */
+  Eq = 'eq',
+  /** Greater Than */
+  Gt = 'gt',
+  /** Greater Than or Equal */
+  Gte = 'gte',
+  /** In used with Array types to filter based on the array containing the value */
+  In = 'in',
+  /** Less Than */
+  Lt = 'lt',
+  /** Less Than or Equal */
+  Lte = 'lte',
+  /** Not Equal to */
+  Ne = 'ne',
+  /** Not In used with Array types to filter based on the array not containing the value */
+  Nin = 'nin',
+  /** Regex used with String types to filter based on the regex pattern */
+  Regex = 'regex'
+}
+
 /** Describes which address should be removed from which account */
 export type RemoveAccountAddressBookEntryInput = {
   /** The account ID */
@@ -6427,6 +6739,25 @@ export type RemoveCartItemsPayload = {
   cart: Cart;
   /** The same string you sent with the mutation params, for matching mutation calls with their responses */
   clientMutationId?: Maybe<Scalars['String']>;
+};
+
+/** Input for the removeCouponFromCart mutation */
+export type RemoveCouponFromCartInput = {
+  /** The account ID of the user who is applying the coupon */
+  accountId?: InputMaybe<Scalars['ID']>;
+  /** The ID of the Cart */
+  cartId: Scalars['ID'];
+  /** The promotion that contains the coupon to remove */
+  promotionId: Scalars['ID'];
+  shopId: Scalars['ID'];
+  /** Cart token, if anonymous */
+  token?: InputMaybe<Scalars['String']>;
+};
+
+/** The response for the removeCouponFromCart mutation */
+export type RemoveCouponFromCartPayload = {
+  __typename?: 'RemoveCouponFromCartPayload';
+  cart?: Maybe<Cart>;
 };
 
 /** Input for an `RemoveDiscountCodeFromCartInput` */
@@ -7013,6 +7344,34 @@ export type SimpleInventoryInfo = {
   productConfiguration: ProductConfiguration;
 };
 
+/** Single Condition for filter, use exactly one of the optional input value type */
+export type SingleConditionInput = {
+  /** Value to filter if it is Boolean input */
+  booleanValue?: InputMaybe<Scalars['Boolean']>;
+  /** Flag to set if the regex is case insensitive */
+  caseSensitive?: InputMaybe<Scalars['Boolean']>;
+  /** Value to filter if it is Date input */
+  dateValue?: InputMaybe<Scalars['DateTime']>;
+  /** Value to filter if it is Float Array input */
+  floatArrayValue?: InputMaybe<Array<InputMaybe<Scalars['Float']>>>;
+  /** Value to filter if it is Float input */
+  floatValue?: InputMaybe<Scalars['Float']>;
+  /** Value to filter if it is Integer Array input */
+  integerArrayValue?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  /** Value to filter if it is Integer input */
+  integerValue?: InputMaybe<Scalars['Int']>;
+  /** Field name */
+  key: Scalars['String'];
+  /** Logical NOT operator to negate the condition */
+  logicalNot?: InputMaybe<Scalars['Boolean']>;
+  /** Relational Operator to join the key and value */
+  relationalOperator: RelationalOperatorTypes;
+  /** Value to filter if it is String Array input */
+  stringArrayValue?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  /** Value to filter if it is String input */
+  stringValue?: InputMaybe<Scalars['String']>;
+};
+
 /** Generated sitemap XML for a single shop */
 export type Sitemap = {
   __typename?: 'Sitemap';
@@ -7091,6 +7450,12 @@ export type StackabilityInput = {
   key: Scalars['String'];
   /** Parameters to be passed to the stackability */
   parameters?: InputMaybe<Scalars['JSONObject']>;
+};
+
+export type StandardCouponPayload = {
+  __typename?: 'StandardCouponPayload';
+  coupon: Coupon;
+  success: Scalars['Boolean'];
 };
 
 /** Storefront route URLs */
@@ -8144,6 +8509,8 @@ export type UpdateProductVariantPayload = {
 
 /** Input for the `updateProductVariantField` mutation */
 export type UpdateProductVariantPricesInput = {
+  /** The type of price for product variant */
+  priceType?: InputMaybe<PriceType>;
   /** Prices to update */
   prices: ProductVariantPricesInput;
   /** ID of shop that owns the variant to update */
@@ -8527,6 +8894,13 @@ export type SendResetPasswordEmailMutationVariables = Exact<{
 
 export type SendResetPasswordEmailMutation = { __typename?: 'Mutation', sendResetPasswordEmail?: boolean | null };
 
+export type CreateStandardCouponMutationVariables = Exact<{
+  input?: InputMaybe<CreateStandardCouponInput>;
+}>;
+
+
+export type CreateStandardCouponMutation = { __typename?: 'Mutation', createStandardCoupon?: { __typename?: 'StandardCouponPayload', success: boolean, coupon: { __typename?: 'Coupon', _id: string } } | null };
+
 export type GetPromotionsQueryVariables = Exact<{
   shopId: Scalars['ID'];
   after?: InputMaybe<Scalars['ConnectionCursor']>;
@@ -8547,7 +8921,7 @@ export type GetPromotionQueryVariables = Exact<{
 }>;
 
 
-export type GetPromotionQuery = { __typename?: 'Query', promotion?: { __typename?: 'Promotion', _id: string, triggerType: TriggerType, promotionType: string, label: string, description: string, enabled: boolean, name: string, state: PromotionState, referenceId: number, shopId: string, startDate: any, endDate?: any | null, createdAt: any, updatedAt: any, triggers?: Array<{ __typename?: 'Trigger', triggerKey: string, triggerParameters?: any | null }> | null, actions?: Array<{ __typename?: 'Action', actionKey: string, actionParameters?: any | null }> | null, stackability?: { __typename?: 'Stackability', key: string, parameters?: any | null } | null } | null };
+export type GetPromotionQuery = { __typename?: 'Query', promotion?: { __typename?: 'Promotion', _id: string, triggerType: TriggerType, promotionType: string, label: string, description: string, enabled: boolean, name: string, state: PromotionState, referenceId: number, shopId: string, startDate: any, endDate?: any | null, createdAt: any, updatedAt: any, triggers?: Array<{ __typename?: 'Trigger', triggerKey: string, triggerParameters?: any | null }> | null, actions?: Array<{ __typename?: 'Action', actionKey: string, actionParameters?: any | null }> | null, stackability?: { __typename?: 'Stackability', key: string, parameters?: any | null } | null, coupon?: { __typename?: 'Coupon', _id: string, name: string, code: string, canUseInStore?: boolean | null } | null } | null };
 
 export type UpdatePromotionMutationVariables = Exact<{
   input?: InputMaybe<PromotionUpdateInput>;
@@ -9182,6 +9556,29 @@ export const useSendResetPasswordEmailMutation = <
       (variables?: SendResetPasswordEmailMutationVariables) => fetcher<SendResetPasswordEmailMutation, SendResetPasswordEmailMutationVariables>(client, SendResetPasswordEmailDocument, variables, headers)(),
       options
     );
+export const CreateStandardCouponDocument = `
+    mutation createStandardCoupon($input: CreateStandardCouponInput) {
+  createStandardCoupon(input: $input) {
+    success
+    coupon {
+      _id
+    }
+  }
+}
+    `;
+export const useCreateStandardCouponMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<CreateStandardCouponMutation, TError, CreateStandardCouponMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<CreateStandardCouponMutation, TError, CreateStandardCouponMutationVariables, TContext>(
+      ['createStandardCoupon'],
+      (variables?: CreateStandardCouponMutationVariables) => fetcher<CreateStandardCouponMutation, CreateStandardCouponMutationVariables>(client, CreateStandardCouponDocument, variables, headers)(),
+      options
+    );
 export const GetPromotionsDocument = `
     query getPromotions($shopId: ID!, $after: ConnectionCursor, $before: ConnectionCursor, $first: ConnectionLimitInt, $last: ConnectionLimitInt, $offset: Int, $filter: PromotionFilter, $sortBy: String, $sortOrder: String) {
   promotions(
@@ -9270,6 +9667,12 @@ export const GetPromotionDocument = `
     }
     createdAt
     updatedAt
+    coupon {
+      _id
+      name
+      code
+      canUseInStore
+    }
   }
 }
     `;

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -8954,7 +8954,7 @@ export type GetPromotionQueryVariables = Exact<{
 }>;
 
 
-export type GetPromotionQuery = { __typename?: 'Query', promotion?: { __typename?: 'Promotion', _id: string, triggerType: TriggerType, promotionType: string, label: string, description: string, enabled: boolean, name: string, state: PromotionState, referenceId: number, shopId: string, startDate: any, endDate?: any | null, createdAt: any, updatedAt: any, triggers?: Array<{ __typename?: 'Trigger', triggerKey: string, triggerParameters?: any | null }> | null, actions?: Array<{ __typename?: 'Action', actionKey: string, actionParameters?: any | null }> | null, stackability?: { __typename?: 'Stackability', key: string, parameters?: any | null } | null, coupon?: { __typename?: 'Coupon', _id: string, name: string, code: string, canUseInStore?: boolean | null } | null } | null };
+export type GetPromotionQuery = { __typename?: 'Query', promotion?: { __typename?: 'Promotion', _id: string, triggerType: TriggerType, promotionType: string, label: string, description: string, enabled: boolean, name: string, state: PromotionState, referenceId: number, shopId: string, startDate: any, endDate?: any | null, createdAt: any, updatedAt: any, triggers?: Array<{ __typename?: 'Trigger', triggerKey: string, triggerParameters?: any | null }> | null, actions?: Array<{ __typename?: 'Action', actionKey: string, actionParameters?: any | null }> | null, stackability?: { __typename?: 'Stackability', key: string, parameters?: any | null } | null, coupon?: { __typename?: 'Coupon', _id: string, name: string, code: string, canUseInStore?: boolean | null, maxUsageTimesPerUser?: number | null } | null } | null };
 
 export type UpdatePromotionMutationVariables = Exact<{
   input?: InputMaybe<PromotionUpdateInput>;
@@ -9728,6 +9728,7 @@ export const GetPromotionDocument = `
       name
       code
       canUseInStore
+      maxUsageTimesPerUser
     }
   }
 }

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -3592,6 +3592,8 @@ export type Mutation = {
   updateShopSettings: UpdateShopSettingsPayload;
   /** Update the SimpleInventory info for a product configuration */
   updateSimpleInventory: UpdateSimpleInventoryPayload;
+  /** Update a standard coupon mutation */
+  updateStandardCoupon?: Maybe<StandardCouponPayload>;
   /** Update a flat rate fulfillment surcharge */
   updateSurcharge: UpdateSurchargePayload;
   /** Updates an existing tag */
@@ -4282,6 +4284,12 @@ export type MutationUpdateShopSettingsArgs = {
 /** Mutations have side effects, such as mutating data or triggering a task */
 export type MutationUpdateSimpleInventoryArgs = {
   input: UpdateSimpleInventoryInput;
+};
+
+
+/** Mutations have side effects, such as mutating data or triggering a task */
+export type MutationUpdateStandardCouponArgs = {
+  input?: InputMaybe<UpdateStandardCouponInput>;
 };
 
 
@@ -8651,6 +8659,24 @@ export type UpdateSimpleInventoryPayload = {
   inventoryInfo: SimpleInventoryInfo;
 };
 
+/** Input for the updateStandardCoupon mutation */
+export type UpdateStandardCouponInput = {
+  /** The coupon ID */
+  _id: Scalars['ID'];
+  /** Can use this coupon in the store */
+  canUseInStore?: InputMaybe<Scalars['Boolean']>;
+  /** The coupon code */
+  code?: InputMaybe<Scalars['String']>;
+  /** The number of times this coupon can be used */
+  maxUsageTimes?: InputMaybe<Scalars['Int']>;
+  /** The number of times this coupon can be used per user */
+  maxUsageTimesPerUser?: InputMaybe<Scalars['Int']>;
+  /** The coupon name */
+  name?: InputMaybe<Scalars['String']>;
+  /** The shop ID */
+  shopId: Scalars['ID'];
+};
+
 /** Input for the `updateSurcharge` mutation */
 export type UpdateSurchargeInput = {
   /** An optional string identifying the mutation call, which will be returned in the response payload */
@@ -8900,6 +8926,13 @@ export type CreateStandardCouponMutationVariables = Exact<{
 
 
 export type CreateStandardCouponMutation = { __typename?: 'Mutation', createStandardCoupon?: { __typename?: 'StandardCouponPayload', success: boolean, coupon: { __typename?: 'Coupon', _id: string } } | null };
+
+export type UpdateStandardCouponMutationVariables = Exact<{
+  input?: InputMaybe<UpdateStandardCouponInput>;
+}>;
+
+
+export type UpdateStandardCouponMutation = { __typename?: 'Mutation', updateStandardCoupon?: { __typename?: 'StandardCouponPayload', success: boolean, coupon: { __typename?: 'Coupon', _id: string } } | null };
 
 export type GetPromotionsQueryVariables = Exact<{
   shopId: Scalars['ID'];
@@ -9577,6 +9610,29 @@ export const useCreateStandardCouponMutation = <
     useMutation<CreateStandardCouponMutation, TError, CreateStandardCouponMutationVariables, TContext>(
       ['createStandardCoupon'],
       (variables?: CreateStandardCouponMutationVariables) => fetcher<CreateStandardCouponMutation, CreateStandardCouponMutationVariables>(client, CreateStandardCouponDocument, variables, headers)(),
+      options
+    );
+export const UpdateStandardCouponDocument = `
+    mutation updateStandardCoupon($input: UpdateStandardCouponInput) {
+  updateStandardCoupon(input: $input) {
+    success
+    coupon {
+      _id
+    }
+  }
+}
+    `;
+export const useUpdateStandardCouponMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<UpdateStandardCouponMutation, TError, UpdateStandardCouponMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<UpdateStandardCouponMutation, TError, UpdateStandardCouponMutationVariables, TContext>(
+      ['updateStandardCoupon'],
+      (variables?: UpdateStandardCouponMutationVariables) => fetcher<UpdateStandardCouponMutation, UpdateStandardCouponMutationVariables>(client, UpdateStandardCouponDocument, variables, headers)(),
       options
     );
 export const GetPromotionsDocument = `

--- a/src/mocks/handlers/promotionsHandlers.ts
+++ b/src/mocks/handlers/promotionsHandlers.ts
@@ -1,7 +1,7 @@
 import { graphql } from "msw";
 import { faker } from "@faker-js/faker";
 
-import { CalculationType, Promotion, PromotionType, Stackability } from "types/promotions";
+import { CalculationType, Promotion, PromotionType, Stackability, TriggerKeys } from "types/promotions";
 import { PromotionState, TriggerType } from "@graphql/generates";
 
 const date = new Date("2022-02-28");
@@ -29,7 +29,7 @@ const promotion = (index: number): Promotion => {
       }
     }],
     triggers: [{
-      triggerKey: "offers",
+      triggerKey: TriggerKeys.Offers,
       triggerParameters: {
         name: "trigger",
         conditions: {

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -1,7 +1,6 @@
 import { FastField, useFormikContext } from "formik";
 import Stack from "@mui/material/Stack";
 import { ChangeEventHandler, KeyboardEventHandler } from "react";
-import Box from "@mui/material/Box";
 
 import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
@@ -43,7 +42,7 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
           onKeyDown={handleKeyDown}
         />
       </Stack>
-      <Box sx={{ width: { md: "300px" } }}>
+      <Stack sx={{ width: { lg: "50%", md: "100%" }, flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 2 }, alignItems: { md: "flex-start" } }}>
         <FastField
           component={SelectField}
           name={`triggers[${index}].triggerParameters.canUseInStore`}
@@ -51,7 +50,8 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
           options={COUPON_USAGE}
           disabled={disabled}
         />
-      </Box>
+        <FastField name={`triggers[${index}].triggerParameters.maxUsageTimesPerUser`} component={TextField} type="number" label="Max # uses per Customer" />
+      </Stack>
     </Stack>
   );
 };

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -1,5 +1,6 @@
-import { Field } from "formik";
+import { FastField, useFormikContext } from "formik";
 import Stack from "@mui/material/Stack";
+import { ChangeEventHandler } from "react";
 
 import { TextField } from "@components/TextField";
 
@@ -7,18 +8,26 @@ export type CouponsFieldProps = {
   index: number
 }
 
-export const CouponsField = ({ index }: CouponsFieldProps) => (
-  <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 } }}>
-    <Field
-      component={TextField}
-      name={`triggers[${index}].triggerParameters.name`}
-      label="Give your coupon a name"
-    />
-    <Field
-      component={TextField}
-      name={`triggers[${index}].triggerParameters.couponCode`}
-      label="Enter the coupon code (avoid characters like I, L, 0, and O)"
-    />
-  </Stack>
+export const CouponsField = ({ index }: CouponsFieldProps) => {
+  const { setFieldValue } = useFormikContext();
 
-);
+  const onChangeCouponCode: ChangeEventHandler<HTMLInputElement> = (event) => {
+    setFieldValue(`triggers[${index}].triggerParameters.couponCode`, event.target.value.toUpperCase());
+  };
+
+  return (
+    <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 } }}>
+      <FastField
+        component={TextField}
+        name={`triggers[${index}].triggerParameters.name`}
+        label="Give your coupon a name"
+      />
+      <FastField
+        component={TextField}
+        onChange={onChangeCouponCode}
+        name={`triggers[${index}].triggerParameters.couponCode`}
+        label="Enter the coupon code (avoid characters like I, L, 0, and O)"
+      />
+    </Stack>
+  );
+};

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -1,0 +1,24 @@
+import { Field } from "formik";
+import Stack from "@mui/material/Stack";
+
+import { TextField } from "@components/TextField";
+
+export type CouponsFieldProps = {
+  index: number
+}
+
+export const CouponsField = ({ index }: CouponsFieldProps) => (
+  <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 } }}>
+    <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.name`}
+      label="Give your coupon a name"
+    />
+    <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.couponCode`}
+      label="Enter the coupon code (avoid characters like I, L, 0, and O)"
+    />
+  </Stack>
+
+);

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -1,6 +1,6 @@
 import { FastField, useFormikContext } from "formik";
 import Stack from "@mui/material/Stack";
-import { ChangeEventHandler } from "react";
+import { ChangeEventHandler, KeyboardEventHandler } from "react";
 import Box from "@mui/material/Box";
 
 import { TextField } from "@components/TextField";
@@ -19,9 +19,16 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
     setFieldValue(`triggers[${index}].triggerParameters.code`, event.target.value.toUpperCase());
   };
 
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (event.code === "Space") {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <Stack direction="column" mb={1}>
-      <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 }, alignItems: { md: "flex-end" } }}>
+      <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 }, alignItems: { md: "flex-start" } }}>
         <FastField
           component={TextField}
           name={`triggers[${index}].triggerParameters.name`}
@@ -33,6 +40,7 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
           name={`triggers[${index}].triggerParameters.code`}
           label="Enter the coupon code (avoid characters like I, L, 0, and O)"
           disabled={disabled}
+          onKeyDown={handleKeyDown}
         />
       </Stack>
       <Box sx={{ width: { md: "300px" } }}>

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -1,8 +1,11 @@
 import { FastField, useFormikContext } from "formik";
 import Stack from "@mui/material/Stack";
 import { ChangeEventHandler } from "react";
+import Box from "@mui/material/Box";
 
 import { TextField } from "@components/TextField";
+import { SelectField } from "@components/SelectField";
+import { COUPON_USAGE } from "../constants";
 
 export type CouponsFieldProps = {
   index: number
@@ -17,19 +20,30 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
   };
 
   return (
-    <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 }, alignItems: { md: "flex-end" } }}>
-      <FastField
-        component={TextField}
-        name={`triggers[${index}].triggerParameters.name`}
-        label="Give your coupon a name"
-      />
-      <FastField
-        component={TextField}
-        onChange={onChangeCouponCode}
-        name={`triggers[${index}].triggerParameters.couponCode`}
-        label="Enter the coupon code (avoid characters like I, L, 0, and O)"
-        disabled={disabled}
-      />
+    <Stack direction="column" mb={1}>
+      <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 }, alignItems: { md: "flex-end" } }}>
+        <FastField
+          component={TextField}
+          name={`triggers[${index}].triggerParameters.name`}
+          label="Give your coupon a name"
+        />
+        <FastField
+          component={TextField}
+          onChange={onChangeCouponCode}
+          name={`triggers[${index}].triggerParameters.couponCode`}
+          label="Enter the coupon code (avoid characters like I, L, 0, and O)"
+          disabled={disabled}
+        />
+      </Stack>
+      <Box sx={{ width: { md: "300px" } }}>
+        <FastField
+          component={SelectField}
+          name={`triggers[${index}].triggerParameters.canUseInStore`}
+          label="Coupon can be used in store?"
+          options={COUPON_USAGE}
+          disabled={disabled}
+        />
+      </Box>
     </Stack>
   );
 };

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -16,7 +16,7 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
   const { setFieldValue } = useFormikContext();
 
   const onChangeCouponCode: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setFieldValue(`triggers[${index}].triggerParameters.couponCode`, event.target.value.toUpperCase());
+    setFieldValue(`triggers[${index}].triggerParameters.code`, event.target.value.toUpperCase());
   };
 
   return (
@@ -30,7 +30,7 @@ export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
         <FastField
           component={TextField}
           onChange={onChangeCouponCode}
-          name={`triggers[${index}].triggerParameters.couponCode`}
+          name={`triggers[${index}].triggerParameters.code`}
           label="Enter the coupon code (avoid characters like I, L, 0, and O)"
           disabled={disabled}
         />

--- a/src/pages/Promotions/Details/CouponsField.tsx
+++ b/src/pages/Promotions/Details/CouponsField.tsx
@@ -6,9 +6,10 @@ import { TextField } from "@components/TextField";
 
 export type CouponsFieldProps = {
   index: number
+  disabled: boolean
 }
 
-export const CouponsField = ({ index }: CouponsFieldProps) => {
+export const CouponsField = ({ index, disabled }: CouponsFieldProps) => {
   const { setFieldValue } = useFormikContext();
 
   const onChangeCouponCode: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -16,7 +17,7 @@ export const CouponsField = ({ index }: CouponsFieldProps) => {
   };
 
   return (
-    <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 } }}>
+    <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 }, alignItems: { md: "flex-end" } }}>
       <FastField
         component={TextField}
         name={`triggers[${index}].triggerParameters.name`}
@@ -27,6 +28,7 @@ export const CouponsField = ({ index }: CouponsFieldProps) => {
         onChange={onChangeCouponCode}
         name={`triggers[${index}].triggerParameters.couponCode`}
         label="Enter the coupon code (avoid characters like I, L, 0, and O)"
+        disabled={disabled}
       />
     </Stack>
   );

--- a/src/pages/Promotions/Details/PromotionActions.tsx
+++ b/src/pages/Promotions/Details/PromotionActions.tsx
@@ -11,7 +11,7 @@ import Alert from "@mui/material/Alert";
 import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
 import { Promotion, PromotionType } from "types/promotions";
-import { CALCULATION_TYPE_OPTIONS, DISCOUNT_TYPES_MAP } from "../constants";
+import { CALCULATION_TYPE_OPTIONS, DISCOUNT_TYPES_MAP, NOOP_ACTION } from "../constants";
 import { AlertDialog } from "@components/Dialog";
 
 import { EligibleItems } from "./EligibleItems";
@@ -46,7 +46,7 @@ export const PromotionActions = () => {
             <Typography variant="subtitle2">Select an action for your promotion</Typography>
             {values.actions.map((_: Action, index: number) =>
               <Paper key={index} variant="outlined" sx={{ padding: 2 }}>
-                {values.actions[index].actionKey === "noop" ?
+                {values.actions[index].actionKey === NOOP_ACTION ?
                   <Typography>Noop Action</Typography> :
                   <>
                     <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/src/pages/Promotions/Details/PromotionActions.tsx
+++ b/src/pages/Promotions/Details/PromotionActions.tsx
@@ -46,64 +46,70 @@ export const PromotionActions = () => {
             <Typography variant="subtitle2">Select an action for your promotion</Typography>
             {values.actions.map((_: Action, index: number) =>
               <Paper key={index} variant="outlined" sx={{ padding: 2 }}>
-                <Stack direction="row" alignItems="center" justifyContent="space-between">
-                  <Stack direction="row" alignItems="flex-start" gap={1} justifyContent="flex-start">
-                    <Field
-                      name={`actions[${index}].actionParameters.discountCalculationType`}
-                      component={SelectField}
-                      hiddenLabel
-                      label="Select Action Calculate Type"
-                      ariaLabel="Calculate Type"
-                      options={calculationTypeOptions}
-                    />
-                    {getSymbolBasedOnType(values.actions[index]) ?
-                      <Field
-                        component={TextField}
-                        name={`actions[${index}].actionParameters.discountValue`}
-                        label="Discount Value"
-                        ariaLabel="Discount Value"
-                        type="number"
-                        hiddenLabel
-                        startAdornment={
-                          <InputAdornment position="start">{getSymbolBasedOnType(values.actions[index])}</InputAdornment>
+                {values.actions[index].actionKey === "noop" ?
+                  <Typography>Noop Action</Typography> :
+                  <>
+                    <Stack direction="row" alignItems="center" justifyContent="space-between">
+                      <Stack direction="row" alignItems="flex-start" gap={1} justifyContent="flex-start">
+                        <Field
+                          name={`actions[${index}].actionParameters.discountCalculationType`}
+                          component={SelectField}
+                          hiddenLabel
+                          label="Select Action Calculate Type"
+                          ariaLabel="Calculate Type"
+                          options={calculationTypeOptions}
+                        />
+                        {getSymbolBasedOnType(values.actions[index]) ?
+                          <Field
+                            component={TextField}
+                            name={`actions[${index}].actionParameters.discountValue`}
+                            label="Discount Value"
+                            ariaLabel="Discount Value"
+                            type="number"
+                            hiddenLabel
+                            startAdornment={
+                              <InputAdornment position="start">{getSymbolBasedOnType(values.actions[index])}</InputAdornment>
+                            }
+                          />
+                          : null}
+                      </Stack>
+                      <Button variant="text" color="error" onClick={() => setActiveField(index)}>
+                 Remove Action
+                      </Button>
+                    </Stack>
+                    {isShippingDiscount ?
+                      <EligibleShippingMethods
+                        inclusionFieldName={
+                          `actions[${index}].actionParameters.inclusionRules.conditions.all`
                         }
                       />
-                      : null}
-                  </Stack>
-                  <Button variant="text" color="error" onClick={() => setActiveField(index)}>
-                  Remove Action
-                  </Button>
-                </Stack>
-                {isShippingDiscount ?
-                  <EligibleShippingMethods
-                    inclusionFieldName={
-                      `actions[${index}].actionParameters.inclusionRules.conditions.all`
-                    }
-                  />
-                  : <EligibleItems
-                    inclusionFieldName={
-                      `actions[${index}].actionParameters.inclusionRules.conditions`
-                    }
-                    exclusionFieldName={`actions[${index}].actionParameters.exclusionRules.conditions`}
-                  />}
+                      : <EligibleItems
+                        inclusionFieldName={
+                          `actions[${index}].actionParameters.inclusionRules.conditions`
+                        }
+                        exclusionFieldName={`actions[${index}].actionParameters.exclusionRules.conditions`}
+                      />}
 
-                <AlertDialog
-                  title="Delete Action"
-                  icon={<DeleteOutlineOutlinedIcon/>}
-                  content={
-                    <>
-                      <Typography variant="subtitle2" color="grey.600">Are you sure you want to delete this action?</Typography>
-                      <Typography variant="subtitle2" color="grey.600">Once you save the promotion, this change cannot be undone.</Typography>
-                    </>}
-                  open={activeField === index}
-                  handleClose={handleClose}
-                  cancelText="Cancel"
-                  confirmText="Delete"
-                  onConfirm={() => {
-                    remove(index);
-                    handleClose();
-                  }}
-                />
+                    <AlertDialog
+                      title="Delete Action"
+                      icon={<DeleteOutlineOutlinedIcon/>}
+                      content={
+                        <>
+                          <Typography variant="subtitle2" color="grey.600">Are you sure you want to delete this action?</Typography>
+                          <Typography variant="subtitle2" color="grey.600">Once you save the promotion, this change cannot be undone.</Typography>
+                        </>}
+                      open={activeField === index}
+                      handleClose={handleClose}
+                      cancelText="Cancel"
+                      confirmText="Delete"
+                      onConfirm={() => {
+                        remove(index);
+                        handleClose();
+                      }}
+                    />
+                  </>
+                }
+
               </Paper>)
             }
             {!values.actions.length ?

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -115,4 +115,28 @@ describe("Promotion Details", () => {
       expect(screen.getByLabelText("Promotion Name")).toHaveValue(enabledPromotions[0].name);
     });
   }, 50000);
+
+  it("should be able to create a coupon promotion", async () => {
+    renderWithProviders(
+      <Routes>
+        <Route element={<AppLayout/>}>
+          <Route path="promotions/:promotionId" element={
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <PromotionDetails/>
+            </LocalizationProvider>}/>
+        </Route>
+      </Routes>
+      , { initialEntries: [`/promotions/${promotion._id}`] }
+    );
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar", { hidden: true }), { timeout: 3000 });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Remove Trigger"));
+    await user.click(within(screen.getByRole("dialog")).getByText("Delete"));
+    await user.click(screen.getByText("Add Trigger"));
+    await user.click(screen.getByLabelText("Select Trigger Type"));
+    await user.click(within(screen.getByRole("listbox")).getByText("Coupon is used (Standard)"));
+    expect(screen.getByLabelText("Give your coupon a name")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Enter the coupon code (avoid characters like I, L, 0, and O)"), "TET2023");
+    await user.click(screen.getByText("Save Changes"));
+  }, 50000);
 });

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -160,6 +160,7 @@ describe("Promotion Details", () => {
 
     await user.click(screen.getByLabelText("Select Trigger Type"));
     await user.click(within(screen.getByRole("listbox")).getByText("Item is in cart"));
-    expect(screen.getByText("Minimum number of items required to trigger promotion")).toBeInTheDocument();
+    expect(screen.getByText("items")).toBeInTheDocument();
+    expect(screen.getByLabelText("Number of items required in cart")).toBeInTheDocument();
   }, 50000);
 });

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -1,5 +1,5 @@
 import Stack from "@mui/material/Stack";
-import { Field, FieldArray } from "formik";
+import { FieldArray } from "formik";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
@@ -8,13 +8,14 @@ import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined
 import { useState } from "react";
 import Alert from "@mui/material/Alert";
 
-import { SelectField } from "@components/SelectField";
 import { TRIGGER_TYPE_OPTIONS } from "../constants";
 import { AlertDialog } from "@components/Dialog";
 import { Trigger, TriggerKeys } from "types/promotions";
 
 import { EligibleItems } from "./EligibleItems";
 import { TriggerValuesField } from "./TriggerValuesField";
+import { TriggerTypeField } from "./TriggerTypeField";
+import { CouponsField } from "./CouponsField";
 
 
 export const PromotionTriggers = () => {
@@ -35,16 +36,7 @@ export const PromotionTriggers = () => {
                     name={`triggers[${index}].triggerParameters.conditions.all`}
                     render={() =>
                       <Grid container spacing={1} width="70%">
-                        <Grid item>
-                          <Field
-                            name={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`}
-                            component={SelectField}
-                            hiddenLabel
-                            label="Select Trigger Type"
-                            options={TRIGGER_TYPE_OPTIONS}
-                            autoWidth
-                          />
-                        </Grid>
+                        <TriggerTypeField trigger={values.triggers[index]} index={index}/>
                         <TriggerValuesField trigger={values.triggers[index]} index={index}/>
                       </Grid>
                     }
@@ -53,6 +45,7 @@ export const PromotionTriggers = () => {
                 Remove Trigger
                   </Button>
                 </Stack>
+                <CouponsField index={index}/>
                 <EligibleItems
                   inclusionFieldName={
                     `triggers[${index}].triggerParameters.inclusionRules.conditions`

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -36,7 +36,7 @@ export const PromotionTriggers = () => {
                     name={`triggers[${index}].triggerParameters.conditions.all`}
                     render={() =>
                       <Grid container spacing={1} width="70%">
-                        <TriggerTypeField trigger={values.triggers[index]} index={index}/>
+                        <TriggerTypeField fieldName={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`} index={index}/>
                         <TriggerValuesField trigger={values.triggers[index]} index={index}/>
                       </Grid>
                     }
@@ -45,7 +45,7 @@ export const PromotionTriggers = () => {
                 Remove Trigger
                   </Button>
                 </Stack>
-                <CouponsField index={index}/>
+                {values.triggers[index].triggerKey === TriggerKeys.Coupons ? <CouponsField index={index}/> : null}
                 <EligibleItems
                   inclusionFieldName={
                     `triggers[${index}].triggerParameters.inclusionRules.conditions`

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -17,8 +17,11 @@ import { TriggerValuesField } from "./TriggerValuesField";
 import { TriggerTypeField } from "./TriggerTypeField";
 import { CouponsField } from "./CouponsField";
 
+type PromotionTriggersProps = {
+  disabled: boolean
+}
 
-export const PromotionTriggers = () => {
+export const PromotionTriggers = ({ disabled }: PromotionTriggersProps) => {
   const [activeField, setActiveField] = useState<number>();
   const handleClose = () => setActiveField(undefined);
 
@@ -45,7 +48,7 @@ export const PromotionTriggers = () => {
                 Remove Trigger
                   </Button>
                 </Stack>
-                {values.triggers[index].triggerKey === TriggerKeys.Coupons ? <CouponsField index={index}/> : null}
+                {values.triggers[index].triggerKey === TriggerKeys.Coupons ? <CouponsField index={index} disabled={disabled}/> : null}
                 <EligibleItems
                   inclusionFieldName={
                     `triggers[${index}].triggerParameters.inclusionRules.conditions`

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -1,4 +1,3 @@
-import InputAdornment from "@mui/material/InputAdornment";
 import Stack from "@mui/material/Stack";
 import { Field, FieldArray } from "formik";
 import Grid from "@mui/material/Grid";
@@ -9,18 +8,19 @@ import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined
 import { useState } from "react";
 import Alert from "@mui/material/Alert";
 
-import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
 import { TRIGGER_TYPE_OPTIONS } from "../constants";
 import { AlertDialog } from "@components/Dialog";
 import { Trigger } from "types/promotions";
 
 import { EligibleItems } from "./EligibleItems";
+import { TriggerValuesField } from "./TriggerValuesField";
 
 
 export const PromotionTriggers = () => {
   const [activeField, setActiveField] = useState<number>();
   const handleClose = () => setActiveField(undefined);
+
   return (
     <Stack direction="column" mt={2} gap={2}>
       <FieldArray
@@ -45,20 +45,7 @@ export const PromotionTriggers = () => {
                             autoWidth
                           />
                         </Grid>
-                        <Grid item>
-                          <Field
-                            component={TextField}
-                            name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
-                            label="Value"
-                            ariaLabel="Trigger Value"
-                            type="number"
-                            hiddenLabel
-                            startAdornment={
-                              <InputAdornment position="start">$</InputAdornment>
-                            }
-                            sx={{ width: "100px" }}
-                          />
-                        </Grid>
+                        <TriggerValuesField trigger={values.triggers[index]} index={index}/>
                       </Grid>
                     }
                   />

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -11,7 +11,7 @@ import Alert from "@mui/material/Alert";
 import { SelectField } from "@components/SelectField";
 import { TRIGGER_TYPE_OPTIONS } from "../constants";
 import { AlertDialog } from "@components/Dialog";
-import { Trigger } from "types/promotions";
+import { Trigger, TriggerKeys } from "types/promotions";
 
 import { EligibleItems } from "./EligibleItems";
 import { TriggerValuesField } from "./TriggerValuesField";
@@ -81,7 +81,7 @@ export const PromotionTriggers = () => {
               color="secondary"
               variant="outlined"
               onClick={() => push({
-                triggerKey: "offers",
+                triggerKey: TriggerKeys.Offers,
                 triggerParameters: {
                   name: values.name,
                   conditions: {

--- a/src/pages/Promotions/Details/PromotionTriggers.tsx
+++ b/src/pages/Promotions/Details/PromotionTriggers.tsx
@@ -39,8 +39,8 @@ export const PromotionTriggers = ({ disabled }: PromotionTriggersProps) => {
                     name={`triggers[${index}].triggerParameters.conditions.all`}
                     render={() =>
                       <Grid container spacing={1} width="70%">
-                        <TriggerTypeField fieldName={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`} index={index}/>
-                        <TriggerValuesField trigger={values.triggers[index]} index={index}/>
+                        <TriggerTypeField fieldName={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`} index={index} disabled={disabled}/>
+                        <TriggerValuesField trigger={values.triggers[index]} index={index} disabled={disabled}/>
                       </Grid>
                     }
                   />

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -17,11 +17,11 @@ export const TriggerTypeField = ({ fieldName, index, disabled }: TriggerTypeFiel
     setFieldValue(fieldName, value);
     if (value.split("-")[0] === TriggerType.CouponStandard) {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Coupons);
-      setFieldValue(`triggers[${index}].triggerParameters.couponCode`, "");
+      setFieldValue(`triggers[${index}].triggerParameters.code`, "");
       setFieldValue(`triggers[${index}].triggerParameters.canUseInStore`, false);
     } else {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Offers);
-      setFieldValue(`triggers[${index}].triggerParameters.couponCode`, undefined);
+      setFieldValue(`triggers[${index}].triggerParameters.code`, undefined);
       setFieldValue(`triggers[${index}].triggerParameters.conditions.all[0].value`, 0);
     }
   };

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -8,14 +8,16 @@ import { Promotion, TriggerKeys, TriggerType } from "types/promotions";
 type TriggerTypeFieldProps = {
   fieldName: string
   index: number
+  disabled: boolean
 }
 
-export const TriggerTypeField = ({ fieldName, index }: TriggerTypeFieldProps) => {
+export const TriggerTypeField = ({ fieldName, index, disabled }: TriggerTypeFieldProps) => {
   const { setFieldValue } = useFormikContext<Promotion>();
   const onTriggerTypeChange = (value: string) => {
     setFieldValue(fieldName, value);
     if (value.split("-")[0] === TriggerType.CouponStandard) {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Coupons);
+      setFieldValue(`triggers[${index}].triggerParameters.couponCode`, "");
     } else {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Offers);
       setFieldValue(`triggers[${index}].triggerParameters.couponCode`, undefined);
@@ -31,9 +33,11 @@ export const TriggerTypeField = ({ fieldName, index }: TriggerTypeFieldProps) =>
             {...props}
             hiddenLabel
             label="Select Trigger Type"
+            ariaLabel="Select Trigger Type"
             options={TRIGGER_TYPE_OPTIONS}
             onChange={(event) => onTriggerTypeChange(event.target.value as string)}
             autoWidth
+            disabled={disabled}
           />}
       </Field>
 

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -18,6 +18,7 @@ export const TriggerTypeField = ({ fieldName, index, disabled }: TriggerTypeFiel
     if (value.split("-")[0] === TriggerType.CouponStandard) {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Coupons);
       setFieldValue(`triggers[${index}].triggerParameters.couponCode`, "");
+      setFieldValue(`triggers[${index}].triggerParameters.canUseInStore`, false);
     } else {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Offers);
       setFieldValue(`triggers[${index}].triggerParameters.couponCode`, undefined);

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -1,29 +1,42 @@
 import Grid from "@mui/material/Grid";
-import { Field, useFormikContext } from "formik";
+import { Field, FieldProps, useFormikContext } from "formik";
 
 import { SelectField } from "@components/SelectField";
 import { TRIGGER_TYPE_OPTIONS } from "../constants";
-import { Promotion, Trigger, TriggerKeys } from "types/promotions";
+import { Promotion, TriggerKeys, TriggerType } from "types/promotions";
 
 type TriggerTypeFieldProps = {
+  fieldName: string
   index: number
-  trigger: Trigger
-
 }
 
-export const TriggerTypeField = ({ index, trigger }: TriggerTypeFieldProps) => {
+export const TriggerTypeField = ({ fieldName, index }: TriggerTypeFieldProps) => {
   const { setFieldValue } = useFormikContext<Promotion>();
+  const onTriggerTypeChange = (value: string) => {
+    setFieldValue(fieldName, value);
+    if (value.split("-")[0] === TriggerType.CouponStandard) {
+      setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Coupons);
+    } else {
+      setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Offers);
+      setFieldValue(`triggers[${index}].triggerParameters.couponCode`, undefined);
+      setFieldValue(`triggers[${index}].triggerParameters.conditions.all[0].value`, 0);
+    }
+  };
 
   return (
     <Grid item>
-      <Field
-        name={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`}
-        component={SelectField}
-        hiddenLabel
-        label="Select Trigger Type"
-        options={TRIGGER_TYPE_OPTIONS}
-        autoWidth
-      />
+      <Field name={fieldName}>
+        {(props: FieldProps) =>
+          <SelectField
+            {...props}
+            hiddenLabel
+            label="Select Trigger Type"
+            options={TRIGGER_TYPE_OPTIONS}
+            onChange={(event) => onTriggerTypeChange(event.target.value as string)}
+            autoWidth
+          />}
+      </Field>
+
     </Grid>
   );
 };

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -18,6 +18,7 @@ export const TriggerTypeField = ({ fieldName, index, disabled }: TriggerTypeFiel
     if (value.split("-")[0] === TriggerType.CouponStandard) {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Coupons);
       setFieldValue(`triggers[${index}].triggerParameters.code`, "");
+      setFieldValue(`triggers[${index}].triggerParameters.maxUsageTimesPerUser`, 0);
       setFieldValue(`triggers[${index}].triggerParameters.canUseInStore`, false);
     } else {
       setFieldValue(`triggers[${index}].triggerKey`, TriggerKeys.Offers);

--- a/src/pages/Promotions/Details/TriggerTypeField.tsx
+++ b/src/pages/Promotions/Details/TriggerTypeField.tsx
@@ -1,0 +1,29 @@
+import Grid from "@mui/material/Grid";
+import { Field, useFormikContext } from "formik";
+
+import { SelectField } from "@components/SelectField";
+import { TRIGGER_TYPE_OPTIONS } from "../constants";
+import { Promotion, Trigger, TriggerKeys } from "types/promotions";
+
+type TriggerTypeFieldProps = {
+  index: number
+  trigger: Trigger
+
+}
+
+export const TriggerTypeField = ({ index, trigger }: TriggerTypeFieldProps) => {
+  const { setFieldValue } = useFormikContext<Promotion>();
+
+  return (
+    <Grid item>
+      <Field
+        name={`triggers[${index}].triggerParameters.conditions.all[0].triggerType`}
+        component={SelectField}
+        hiddenLabel
+        label="Select Trigger Type"
+        options={TRIGGER_TYPE_OPTIONS}
+        autoWidth
+      />
+    </Grid>
+  );
+};

--- a/src/pages/Promotions/Details/TriggerValuesField.tsx
+++ b/src/pages/Promotions/Details/TriggerValuesField.tsx
@@ -8,8 +8,10 @@ import { Trigger, TriggerKeys, TriggerType } from "types/promotions";
 type TriggerValuesFieldProps = {
   trigger: Trigger
   index: number
+  disabled: boolean
 }
-export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) => {
+
+export const TriggerValuesField = ({ trigger, index, disabled }: TriggerValuesFieldProps) => {
   const triggerType = trigger.triggerKey === TriggerKeys.Offers ? trigger.triggerParameters?.conditions.all?.[0].triggerType?.split("-")[0] : null;
 
   const fieldComponentMap: Record<string, JSX.Element> = {
@@ -24,6 +26,7 @@ export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) 
         <InputAdornment position="start">$</InputAdornment>
       }
       sx={{ width: "100px" }}
+      disabled={disabled}
     />,
     [TriggerType.ItemCount]: <Field
       component={TextField}
@@ -36,6 +39,7 @@ export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) 
         <InputAdornment position="end">items</InputAdornment>
       }
       sx={{ width: "130px" }}
+      disabled={disabled}
     />
   };
 

--- a/src/pages/Promotions/Details/TriggerValuesField.tsx
+++ b/src/pages/Promotions/Details/TriggerValuesField.tsx
@@ -1,0 +1,47 @@
+import Grid from "@mui/material/Grid";
+import InputAdornment from "@mui/material/InputAdornment";
+import { Field } from "formik";
+
+import { TextField } from "@components/TextField";
+import { Trigger, TriggerType } from "types/promotions";
+
+type TriggerValuesFieldProps = {
+  trigger: Trigger
+  index: number
+}
+export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) => {
+  const triggerType = trigger.triggerParameters?.conditions.all?.[0].triggerType?.split("-")[0];
+
+  const fieldComponentMap: Record<string, JSX.Element> = {
+    [TriggerType.ItemAmount]: <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
+      label="Value"
+      ariaLabel="Trigger Value"
+      type="number"
+      hiddenLabel
+      startAdornment={
+        <InputAdornment position="start">$</InputAdornment>
+      }
+      sx={{ width: "100px" }}
+    />,
+    [TriggerType.ItemCount]: <Field
+      component={TextField}
+      name={`triggers[${index}].triggerParameters.conditions.all[0].value`}
+      label="Number of items required in cart"
+      ariaLabel="Number of items required in cart"
+      type="number"
+      hiddenLabel
+      endAdornment={
+        <InputAdornment position="end">items</InputAdornment>
+      }
+      sx={{ width: "130px" }}
+    />
+  };
+
+  return triggerType ?
+    (
+      <Grid item>{fieldComponentMap[triggerType]}</Grid>
+    )
+    : null;
+};

--- a/src/pages/Promotions/Details/TriggerValuesField.tsx
+++ b/src/pages/Promotions/Details/TriggerValuesField.tsx
@@ -3,14 +3,14 @@ import InputAdornment from "@mui/material/InputAdornment";
 import { Field } from "formik";
 
 import { TextField } from "@components/TextField";
-import { Trigger, TriggerType } from "types/promotions";
+import { Trigger, TriggerKeys, TriggerType } from "types/promotions";
 
 type TriggerValuesFieldProps = {
   trigger: Trigger
   index: number
 }
 export const TriggerValuesField = ({ trigger, index }: TriggerValuesFieldProps) => {
-  const triggerType = trigger.triggerParameters?.conditions.all?.[0].triggerType?.split("-")[0];
+  const triggerType = trigger.triggerKey === TriggerKeys.Offers ? trigger.triggerParameters?.conditions.all?.[0].triggerType?.split("-")[0] : null;
 
   const fieldComponentMap: Record<string, JSX.Element> = {
     [TriggerType.ItemAmount]: <Field

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -92,6 +92,11 @@ const PromotionDetails = () => {
     error(message || `Failed to ${promotionId ? "update" : "create"} a promotion.`);
   };
 
+  const handleCouponError = (errorResponse: unknown) => {
+    const { message } = formatErrorResponse(errorResponse);
+    error(message || `Failed to ${promotionId ? "update" : "create"} a coupon.`);
+  };
+
   const onSubmit: FormikConfig<PromotionFormValue>["onSubmit"] = (
     values,
     { setSubmitting }
@@ -104,9 +109,9 @@ const PromotionDetails = () => {
       if (coupons.length) {
         coupons.forEach((coupon) => {
           if (coupon._id) {
-            updateCoupon({ input: { ...coupon, shopId: shopId!, _id: coupon._id } });
+            updateCoupon({ input: { ...coupon, shopId: shopId!, _id: coupon._id } }, { onError: handleCouponError });
           } else {
-            createCoupon({ input: { ...coupon, shopId: shopId!, promotionId } });
+            createCoupon({ input: { ...coupon, shopId: shopId!, promotionId } }, { onError: handleCouponError });
           }
         });
       }
@@ -134,7 +139,7 @@ const PromotionDetails = () => {
           const newPromotionId = responseData.createPromotion?.promotion?._id;
           if (coupons.length && newPromotionId) {
             coupons.forEach((coupon) => {
-              createCoupon({ input: { ...coupon, shopId: shopId!, promotionId: newPromotionId } });
+              createCoupon({ input: { ...coupon, shopId: shopId!, promotionId: newPromotionId } }, { onError: handleCouponError });
             });
           }
           newPromotionId ? navigate(`/promotions/${newPromotionId}`) : navigate("/promotions");

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -11,7 +11,8 @@ import Box from "@mui/material/Box";
 import { client } from "@graphql/graphql-request-client";
 import { useShop } from "@containers/ShopProvider";
 import { PromotionState, useCreatePromotionMutation, useCreateStandardCouponMutation, useGetPromotionQuery,
-  useUpdatePromotionMutation } from "@graphql/generates";
+  useUpdatePromotionMutation,
+  useUpdateStandardCouponMutation } from "@graphql/generates";
 import { PROMOTION_STACKABILITY_OPTIONS, PROMOTION_TYPE_OPTIONS } from "../constants";
 import { Promotion, PromotionType } from "types/promotions";
 import { useGlobalBreadcrumbs } from "@hooks/useGlobalBreadcrumbs";
@@ -84,6 +85,7 @@ const PromotionDetails = () => {
   const { mutate: createPromotion } = useCreatePromotionMutation(client);
   const { mutate: updatePromotion } = useUpdatePromotionMutation(client);
   const { mutate: createCoupon } = useCreateStandardCouponMutation(client);
+  const { mutate: updateCoupon } = useUpdateStandardCouponMutation(client);
 
   const onError = (errorResponse: unknown) => {
     const { message } = formatErrorResponse(errorResponse);
@@ -99,6 +101,15 @@ const PromotionDetails = () => {
     if (promotionId && data?.promotion) {
       const { triggerType, shopId: promotionShopId } = data.promotion;
       const updatedPromotion = { _id: promotionId, shopId: promotionShopId, triggerType, ...normalizedValues };
+      if (coupons.length) {
+        coupons.forEach((coupon) => {
+          if (coupon._id) {
+            updateCoupon({ input: { ...coupon, shopId: shopId!, _id: coupon._id } });
+          } else {
+            createCoupon({ input: { ...coupon, shopId: shopId!, promotionId } });
+          }
+        });
+      }
       updatePromotion(
         { input: updatedPromotion },
         {

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -12,7 +12,7 @@ import { client } from "@graphql/graphql-request-client";
 import { useShop } from "@containers/ShopProvider";
 import { PromotionState, useCreatePromotionMutation, useGetPromotionQuery, useUpdatePromotionMutation } from "@graphql/generates";
 import { PROMOTION_STACKABILITY_OPTIONS, PROMOTION_TYPE_OPTIONS } from "../constants";
-import { Promotion, PromotionType, Trigger } from "types/promotions";
+import { Promotion, PromotionType } from "types/promotions";
 import { useGlobalBreadcrumbs } from "@hooks/useGlobalBreadcrumbs";
 import { TextField } from "@components/TextField";
 import { SelectField } from "@components/SelectField";
@@ -27,7 +27,7 @@ import { PromotionTriggers } from "./PromotionTriggers";
 import { promotionSchema } from "./validation";
 import { AvailableDateField } from "./AvailableDateField";
 import { PromotionTypeField } from "./PromotionTypeField";
-import { normalizeActionsData, normalizeTriggersData } from "./utils";
+import { formatTriggers, normalizeActionsData, normalizeTriggersData } from "./utils";
 
 type PromotionFormValue = {
   name: string
@@ -42,19 +42,6 @@ type PromotionFormValue = {
   enabled: boolean
 }
 
-
-const getTriggerType = (triggerConditionAll?: {fact: string, operator: string, value: number}[]) => (triggerConditionAll ? triggerConditionAll
-  .map((conditionAll) => ({ ...conditionAll, triggerType: `${conditionAll.fact}-${conditionAll.operator}` })) : []);
-
-const formatTriggers = (triggers: Trigger[], promotionName: string) =>
-  triggers.map((trigger) => ({
-    ...trigger,
-    triggerParameters: {
-      ...trigger.triggerParameters,
-      name: trigger.triggerParameters?.name || promotionName,
-      conditions: { all: getTriggerType(trigger.triggerParameters?.conditions.all) }
-    }
-  }));
 
 const normalizeFormValues = (values: PromotionFormValue) =>
   ({

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -127,7 +127,7 @@ const PromotionDetails = () => {
   };
 
   const showActionButtons = promotionId ? canUpdate : canCreate;
-  const shouldDisableField = data?.promotion.enabled && data?.promotion.state === PromotionState.Active;
+  const shouldDisableField = !!(data?.promotion.enabled && data?.promotion.state === PromotionState.Active);
 
 
   if (isLoading) return <Loader/>;
@@ -194,7 +194,7 @@ const PromotionDetails = () => {
             </Card>
             <Card title="Promotion Builder" divider>
               <PromotionActions/>
-              <PromotionTriggers />
+              <PromotionTriggers disabled={shouldDisableField}/>
             </Card>
             <Card title="Promotion Stackability" divider>
               <Box mt={1} width="50%">

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -1,4 +1,4 @@
-import { Action, Rule, Trigger } from "types/promotions";
+import { Action, Rule, Trigger, TriggerKeys } from "types/promotions";
 
 const normalizeRule = (rule?: Rule) => {
   const newRule = { ...rule };
@@ -30,3 +30,29 @@ export const normalizeActionsData = (actions?: Action[]) => actions?.map((action
     exclusionRules: normalizeRule(action.actionParameters?.exclusionRules)
   }
 }));
+
+
+const getTriggerType = (triggerConditionAll?: {fact: string, operator: string, value: number}[]) => (triggerConditionAll ? triggerConditionAll
+  .map((conditionAll) => ({ ...conditionAll, triggerType: `${conditionAll.fact}-${conditionAll.operator}` })) : []);
+
+
+const formatOffersTrigger = (trigger: Trigger<TriggerKeys.Offers>, promotionName: string) => ({
+  ...trigger,
+  triggerParameters: {
+    ...trigger.triggerParameters,
+    name: trigger.triggerParameters?.name || promotionName,
+    conditions: { all: getTriggerType(trigger.triggerParameters?.conditions.all) }
+  }
+});
+
+export const formatTriggers = (triggers: Trigger[], promotionName: string) =>
+  triggers.map((trigger) => {
+    const { triggerKey } = trigger;
+
+    const formatFn = {
+      [TriggerKeys.Offers]: formatOffersTrigger,
+      [TriggerKeys.Coupons]: () => {}
+    };
+
+    return formatFn[triggerKey](trigger, promotionName);
+  });

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -1,4 +1,4 @@
-import { Action, Rule, Trigger, TriggerKeys } from "types/promotions";
+import { Action, Rule, Trigger, TriggerKeys, TriggerType } from "types/promotions";
 
 const normalizeRule = (rule?: Rule) => {
   const newRule = { ...rule };
@@ -45,13 +45,22 @@ const formatOffersTrigger = (trigger: Trigger<TriggerKeys.Offers>, promotionName
   }
 });
 
+const formatCouponsTrigger = (trigger: Trigger<TriggerKeys.Coupons>) => ({
+  ...trigger,
+  triggerParameters: {
+    name: trigger.triggerParameters.name,
+    conditions: { all: [{ triggerType: TriggerType.CouponStandard }] },
+    couponCode: trigger.triggerParameters.couponCode
+  }
+});
+
 export const formatTriggers = (triggers: Trigger[], promotionName: string) =>
   triggers.map((trigger) => {
     const { triggerKey } = trigger;
 
     const formatFn = {
       [TriggerKeys.Offers]: formatOffersTrigger,
-      [TriggerKeys.Coupons]: () => {}
+      [TriggerKeys.Coupons]: formatCouponsTrigger
     };
 
     return formatFn[triggerKey](trigger, promotionName);

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -79,7 +79,16 @@ export const formatTriggers = (triggers: Trigger[], promotionName: string, coupo
           _id: coupon._id,
           maxUsageTimesPerUser: coupon.maxUsageTimesPerUser || 0
         }
-      } : trigger
+      } : {
+        ...trigger,
+        triggerParameters: {
+          name: trigger.triggerParameters?.name || promotionName,
+          conditions: { all: [{ triggerType: TriggerType.CouponStandard }] },
+          code: "",
+          canUseInStore: false,
+          maxUsageTimesPerUser: 0
+        }
+      }
     };
 
     return formatFn[triggerKey];

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -59,7 +59,8 @@ const formatCouponsTrigger = (trigger: Trigger<TriggerKeys.Coupons>) => ({
   triggerParameters: {
     name: trigger.triggerParameters.name,
     conditions: { all: [{ triggerType: TriggerType.CouponStandard }] },
-    couponCode: trigger.triggerParameters.couponCode
+    couponCode: trigger.triggerParameters.couponCode,
+    canUseInStore: trigger.triggerParameters.canUseInStore || false
   }
 });
 

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -15,7 +15,10 @@ export const normalizeTriggersData = (triggers?: Trigger[]) => triggers?.map((tr
     ...trigger.triggerParameters,
     inclusionRules: normalizeRule(trigger.triggerParameters?.inclusionRules),
     exclusionRules: normalizeRule(trigger.triggerParameters?.exclusionRules),
-    conditions: { all: trigger.triggerParameters?.conditions.all.map(({ triggerType, ...condition }) => condition) }
+    conditions: {
+      all: trigger.triggerParameters?.conditions.all
+        .map(({ triggerType, value }) => ({ fact: triggerType?.split("-")[0], operator: triggerType?.split("-")[1], value }))
+    }
   }
 }));
 

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -1,4 +1,4 @@
-import { Coupon, CouponCreateInput } from "types/coupons";
+import { Coupon, CouponInput } from "types/coupons";
 import { Action, Rule, Trigger, TriggerKeys, TriggerType } from "types/promotions";
 
 const normalizeRule = (rule?: Rule) => {
@@ -11,12 +11,12 @@ const normalizeRule = (rule?: Rule) => {
 };
 
 export const normalizeTriggersData = (triggers?: Trigger[]) => {
-  const coupons: CouponCreateInput[] = [];
+  const coupons: CouponInput[] = [];
 
   const handler = {
     [TriggerKeys.Coupons]: (trigger: Trigger<TriggerKeys.Coupons>) => {
-      const { code, name, canUseInStore } = trigger.triggerParameters;
-      coupons.push({ code, name, canUseInStore });
+      const { code, name, canUseInStore, _id } = trigger.triggerParameters;
+      coupons.push({ code, name, canUseInStore, _id });
       return {
         triggerKey: trigger.triggerKey,
         triggerParameters: {
@@ -75,7 +75,8 @@ export const formatTriggers = (triggers: Trigger[], promotionName: string, coupo
           name: coupon.name,
           conditions: { all: [{ triggerType: TriggerType.CouponStandard }] },
           code: coupon.code,
-          canUseInStore: coupon.canUseInStore
+          canUseInStore: coupon.canUseInStore,
+          _id: coupon._id
         }
       } : trigger
     };

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -15,8 +15,8 @@ export const normalizeTriggersData = (triggers?: Trigger[]) => {
 
   const handler = {
     [TriggerKeys.Coupons]: (trigger: Trigger<TriggerKeys.Coupons>) => {
-      const { code, name, canUseInStore, _id } = trigger.triggerParameters;
-      coupons.push({ code, name, canUseInStore, _id });
+      const { code, name, canUseInStore, _id, maxUsageTimesPerUser } = trigger.triggerParameters;
+      coupons.push({ code, name, canUseInStore, _id, maxUsageTimesPerUser });
       return {
         triggerKey: trigger.triggerKey,
         triggerParameters: {
@@ -76,7 +76,8 @@ export const formatTriggers = (triggers: Trigger[], promotionName: string, coupo
           conditions: { all: [{ triggerType: TriggerType.CouponStandard }] },
           code: coupon.code,
           canUseInStore: coupon.canUseInStore,
-          _id: coupon._id
+          _id: coupon._id,
+          maxUsageTimesPerUser: coupon.maxUsageTimesPerUser || 0
         }
       } : trigger
     };

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -9,16 +9,25 @@ const normalizeRule = (rule?: Rule) => {
   return newRule.conditions ? newRule : undefined;
 };
 
+const normalizeTriggerCondition = (trigger: Trigger) => {
+  const handler = {
+    [TriggerKeys.Offers]: {
+      all: trigger.triggerParameters?.conditions.all
+        .map(({ triggerType, value }) => ({ fact: triggerType?.split("-")[0], operator: triggerType?.split("-")[1], value }))
+    },
+    [TriggerKeys.Coupons]: undefined
+  };
+
+  return handler[trigger.triggerKey];
+};
+
 export const normalizeTriggersData = (triggers?: Trigger[]) => triggers?.map((trigger) => ({
   ...trigger,
   triggerParameters: {
     ...trigger.triggerParameters,
     inclusionRules: normalizeRule(trigger.triggerParameters?.inclusionRules),
     exclusionRules: normalizeRule(trigger.triggerParameters?.exclusionRules),
-    conditions: {
-      all: trigger.triggerParameters?.conditions.all
-        .map(({ triggerType, value }) => ({ fact: triggerType?.split("-")[0], operator: triggerType?.split("-")[1], value }))
-    }
+    conditions: normalizeTriggerCondition(trigger)
   }
 }));
 

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -27,7 +27,7 @@ export const normalizeTriggersData = (triggers?: Trigger[]) => {
     [TriggerKeys.Offers]: (trigger: Trigger) => ({
       ...trigger,
       triggerParameters: {
-        ...trigger.triggerParameters,
+        name: trigger.triggerParameters?.name,
         inclusionRules: normalizeRule(trigger.triggerParameters?.inclusionRules),
         exclusionRules: normalizeRule(trigger.triggerParameters?.exclusionRules),
         conditions: {

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -49,6 +49,8 @@ export const promotionSchema = Yup.object().shape({
             then: (schema) => schema.notRequired(),
             otherwise: (schema) => schema.required("This field is required").moreThan(0, "Discount value must be greater than 0")
           }),
+        discountMaxUnits: Yup.number().min(0, "This field must be greater than or equal to 0"),
+        discountMaxValue: Yup.number().min(0, "This field must be greater than or equal to 0"),
         discountCalculationType: Yup.string().required("This field is required"),
         discountType: Yup.string().required(),
         inclusionRules: Yup.object().when("discountType", {
@@ -93,6 +95,7 @@ export const promotionSchema = Yup.object().shape({
       then: () => Yup.object({
         code: Yup.string().trim().required("This field is required"),
         name: Yup.string().trim().required("This field is required"),
+        maxUsageTimesPerUser: Yup.number().min(0, "This field must be greater than or equal to 0"),
         ...inclusionExclusionValidation
       }),
       otherwise: (schema) => schema

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -93,7 +93,7 @@ export const promotionSchema = Yup.object().shape({
     }).when("triggerKey", {
       is: TriggerKeys.Coupons,
       then: () => Yup.object({
-        code: Yup.string().trim().required("This field is required"),
+        code: Yup.string().trim().required("This field is required").matches(/^[a-zA-Z0-9]+$/, "Please enter an alphanumeric coupon code"),
         name: Yup.string().trim().required("This field is required"),
         maxUsageTimesPerUser: Yup.number().min(0, "This field must be greater than or equal to 0"),
         ...inclusionExclusionValidation

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -58,7 +58,7 @@ export const promotionSchema = Yup.object().shape({
     triggerParameters: Yup.object({
       conditions: Yup.object({
         all: Yup.array().of(Yup.object({
-          value: Yup.number().moreThan(0, "Cart value must be greater than 0").required("This field is required")
+          value: Yup.number().moreThan(0, "This field must be greater than 0").required("This field is required")
         }))
       }),
       inclusionRules: Yup.object({

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -3,7 +3,11 @@ import * as Yup from "yup";
 const ruleSchema = Yup.object({
   path: Yup.string().required("This field is required"),
   operator: Yup.string().required("This field is required"),
-  value: Yup.array().min(1, "This field must have at least 1 item")
+  value: Yup.array().min(1, "This field must have at least 1 value").when("operator", {
+    is: "equal",
+    then: (schema) => schema.length(1, "Change the operator to \"Is Any Of\" to add multiple values"),
+    otherwise: (schema) => schema
+  })
 });
 
 const shippingRuleSchema = Yup.object({ value: Yup.array().min(1, "This field must have at least 1 item") });

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -1,5 +1,8 @@
 import * as Yup from "yup";
 
+import { TriggerType } from "types/promotions";
+import { NOOP_ACTION } from "../constants";
+
 const ruleSchema = Yup.object({
   path: Yup.string().required("This field is required"),
   operator: Yup.string().required("This field is required"),
@@ -18,37 +21,41 @@ export const promotionSchema = Yup.object().shape({
   description: Yup.string().max(5000, "This field must be at most 5000 characters"),
   actions: Yup.array().of(Yup.object({
     actionKey: Yup.string(),
-    actionParameters: Yup.object({
-      discountValue: Yup.number()
-        .when("discountCalculationType", {
-          is: "percentage",
-          then: (schema) => schema.max(100, "This field must be less than or equal to 100%"),
-          otherwise: (schema) => schema
-        }).when("discountCalculationType", {
-          is: "flat",
-          then: (schema) => schema.notRequired(),
-          otherwise: (schema) => schema.required("This field is required").moreThan(0, "Discount value must be greater than 0")
-        }),
-      discountCalculationType: Yup.string().required("This field is required"),
-      discountType: Yup.string().required(),
-      inclusionRules: Yup.object().when("discountType", {
-        is: "shipping",
-        then: (schema) => schema.shape({
-          conditions: Yup.object({
-            all: Yup.array().of(shippingRuleSchema)
+    actionParameters: Yup.object().when("actionKey", {
+      is: NOOP_ACTION,
+      then: (schema) => schema,
+      otherwise: () => Yup.object({
+        discountValue: Yup.number()
+          .when("discountCalculationType", {
+            is: "percentage",
+            then: (schema) => schema.max(100, "This field must be less than or equal to 100%"),
+            otherwise: (schema) => schema
+          }).when("discountCalculationType", {
+            is: "flat",
+            then: (schema) => schema.notRequired(),
+            otherwise: (schema) => schema.required("This field is required").moreThan(0, "Discount value must be greater than 0")
+          }),
+        discountCalculationType: Yup.string().required("This field is required"),
+        discountType: Yup.string().required(),
+        inclusionRules: Yup.object().when("discountType", {
+          is: "shipping",
+          then: (schema) => schema.shape({
+            conditions: Yup.object({
+              all: Yup.array().of(shippingRuleSchema)
+            })
+          }),
+          otherwise: (schema) => schema.shape({
+            conditions: Yup.object({
+              any: Yup.array().of(ruleSchema),
+              all: Yup.array().of(ruleSchema)
+            })
           })
         }),
-        otherwise: (schema) => schema.shape({
+        exclusionRules: Yup.object({
           conditions: Yup.object({
             any: Yup.array().of(ruleSchema),
             all: Yup.array().of(ruleSchema)
           })
-        })
-      }),
-      exclusionRules: Yup.object({
-        conditions: Yup.object({
-          any: Yup.array().of(ruleSchema),
-          all: Yup.array().of(ruleSchema)
         })
       })
     })
@@ -58,7 +65,12 @@ export const promotionSchema = Yup.object().shape({
     triggerParameters: Yup.object({
       conditions: Yup.object({
         all: Yup.array().of(Yup.object({
-          value: Yup.number().moreThan(0, "This field must be greater than 0").required("This field is required")
+          triggerType: Yup.string(),
+          value: Yup.number().when("triggerType", {
+            is: TriggerType.CouponStandard,
+            then: (schema) => schema,
+            otherwise: Yup.number().moreThan(0, "This field must be greater than 0").required("This field is required")
+          })
         }))
       }),
       inclusionRules: Yup.object({

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -27,7 +27,8 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
 ];
 
 export const TRIGGER_TYPE_OPTIONS = [
-  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" }
+  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
+  { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
 ];
 
 

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -54,4 +54,9 @@ export const CONDITION_OPERATORS: Record<string, SelectOptionType & {fieldPrefix
   any: { label: "any of", value: "any", fieldPrefix: "or" }
 };
 
+export const COUPON_USAGE: SelectOptionType<boolean>[] = [
+  { label: "Online Only", value: false },
+  { label: "Online and In Store", value: true }
+];
+
 export const NOOP_ACTION = "noop";

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -1,5 +1,5 @@
 import { SelectOptionType } from "types/common";
-import { CalculationType, PromotionType, Stackability, TriggerType } from "types/promotions";
+import { CalculationType, PromotionType, Stackability, TriggerType, TriggerKeys } from "types/promotions";
 
 export const CALCULATION_TYPE_OPTIONS: Record<CalculationType, SelectOptionType<CalculationType> & {symbol?: string}> = {
   percentage: { label: "% Off", value: CalculationType.Percentage, symbol: "%" },
@@ -26,9 +26,10 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
   { label: "Stack All", value: Stackability.All }
 ];
 
-export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType> = {
-  totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
-  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
+export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType & {triggerKey: TriggerKeys}> = {
+  totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive", triggerKey: TriggerKeys.Offers },
+  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive", triggerKey: TriggerKeys.Offers },
+  couponStandard: { label: "Coupon is used (Standard)", value: "couponStandard", triggerKey: TriggerKeys.Coupons }
 };
 
 export const TRIGGER_TYPE_OPTIONS = Object.values(TRIGGER_TYPE_MAP);

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -28,7 +28,7 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
 
 export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType & {triggerKey: TriggerKeys}> = {
   totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive", triggerKey: TriggerKeys.Offers },
-  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive", triggerKey: TriggerKeys.Offers },
+  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanInclusive", triggerKey: TriggerKeys.Offers },
   couponStandard: { label: "Coupon is used (Standard)", value: "couponStandard", triggerKey: TriggerKeys.Coupons }
 };
 

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -53,3 +53,5 @@ export const CONDITION_OPERATORS: Record<string, SelectOptionType & {fieldPrefix
   all: { label: "all", value: "all", fieldPrefix: "and" },
   any: { label: "any of", value: "any", fieldPrefix: "or" }
 };
+
+export const NOOP_ACTION = "noop";

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -1,5 +1,5 @@
 import { SelectOptionType } from "types/common";
-import { CalculationType, PromotionType, Stackability } from "types/promotions";
+import { CalculationType, PromotionType, Stackability, TriggerType } from "types/promotions";
 
 export const CALCULATION_TYPE_OPTIONS: Record<CalculationType, SelectOptionType<CalculationType> & {symbol?: string}> = {
   percentage: { label: "% Off", value: CalculationType.Percentage, symbol: "%" },
@@ -26,10 +26,12 @@ export const PROMOTION_STACKABILITY_OPTIONS: SelectOptionType<Stackability>[] = 
   { label: "Stack All", value: Stackability.All }
 ];
 
-export const TRIGGER_TYPE_OPTIONS = [
-  { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
-  { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
-];
+export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType> = {
+  totalItemAmount: { label: "Cart Value is greater than", value: "totalItemAmount-greaterThanInclusive" },
+  totalItemCount: { label: "Item is in cart", value: "totalItemCount-greaterThanExclusive" }
+};
+
+export const TRIGGER_TYPE_OPTIONS = Object.values(TRIGGER_TYPE_MAP);
 
 
 export const OPERATOR_OPTIONS: SelectOptionType[] = [

--- a/src/pages/Promotions/coupons.graphql
+++ b/src/pages/Promotions/coupons.graphql
@@ -15,3 +15,12 @@ mutation updateStandardCoupon($input: UpdateStandardCouponInput) {
     }
   }
 }
+
+mutation archiveCoupon($input: ArchiveCouponInput) {
+  archiveCoupon(input: $input) {
+    success
+    coupon {
+      _id
+    }
+  }
+}

--- a/src/pages/Promotions/coupons.graphql
+++ b/src/pages/Promotions/coupons.graphql
@@ -6,3 +6,12 @@ mutation createStandardCoupon($input: CreateStandardCouponInput) {
     }
   }
 }
+
+mutation updateStandardCoupon($input: UpdateStandardCouponInput) {
+  updateStandardCoupon(input: $input) {
+    success
+    coupon {
+      _id
+    }
+  }
+}

--- a/src/pages/Promotions/coupons.graphql
+++ b/src/pages/Promotions/coupons.graphql
@@ -1,0 +1,8 @@
+mutation createStandardCoupon($input: CreateStandardCouponInput) {
+  createStandardCoupon(input: $input) {
+    success
+    coupon {
+      _id
+    }
+  }
+}

--- a/src/pages/Promotions/hooks.ts
+++ b/src/pages/Promotions/hooks.ts
@@ -1,21 +1,27 @@
 import { useToast } from "@containers/ToastProvider";
 import { useUpdatePromotionMutation, useArchivePromotionMutation, PromotionState } from "@graphql/generates";
 import { client } from "@graphql/graphql-request-client";
+import { formatErrorResponse } from "@utils/errorHandlers";
 import { Promotion } from "types/promotions";
 
 const getUpdatePromotionInput = (promotion: Promotion) => {
-  const { referenceId, state, createdAt, updatedAt, ...restPromotion } = promotion;
+  const { referenceId, state, createdAt, updatedAt, coupon, ...restPromotion } = promotion;
   return restPromotion;
 };
 
 export const useEnablePromotion = (onSuccess?: () => void) => {
   const { mutate: update } = useUpdatePromotionMutation(client);
-  const { success } = useToast();
+
+  const { success, error } = useToast();
   const enablePromotions = (promotions: Promotion[]) => {
     promotions.forEach((promotion) => update({ input: { ...getUpdatePromotionInput(promotion), enabled: true } }, {
       onSuccess: () => {
         onSuccess?.();
         success(promotions.length === 1 ? "Enabled promotion successfully" : "Enabled promotions successfully");
+      },
+      onError: (errorResponse) => {
+        const { message } = formatErrorResponse(errorResponse);
+        error(message || "Failed to enable this promotion");
       }
     }));
   };
@@ -25,7 +31,7 @@ export const useEnablePromotion = (onSuccess?: () => void) => {
 
 export const useDisablePromotion = (onSuccess?: () => void) => {
   const { mutate: update } = useUpdatePromotionMutation(client);
-  const { success } = useToast();
+  const { success, error } = useToast();
 
   const disablePromotions = (promotions: Promotion[]) => {
     promotions.forEach((promotion) => update({
@@ -39,6 +45,10 @@ export const useDisablePromotion = (onSuccess?: () => void) => {
       onSuccess: () => {
         onSuccess?.();
         success(promotions.length === 1 ? "Disabled promotion successfully" : "Disabled promotions successfully");
+      },
+      onError: (errorResponse) => {
+        const { message } = formatErrorResponse(errorResponse);
+        error(message || "Failed to enable this promotion");
       }
     }));
   };

--- a/src/pages/Promotions/hooks.ts
+++ b/src/pages/Promotions/hooks.ts
@@ -58,4 +58,3 @@ export const useArchivePromotions = (onSuccess?: () => void) => {
   };
   return { archivePromotions };
 };
-

--- a/src/pages/Promotions/promotions.graphql
+++ b/src/pages/Promotions/promotions.graphql
@@ -75,6 +75,7 @@ query getPromotion($input: PromotionQueryInput) {
         name
         code
         canUseInStore
+        maxUsageTimesPerUser
       }
   }
 }

--- a/src/pages/Promotions/promotions.graphql
+++ b/src/pages/Promotions/promotions.graphql
@@ -70,6 +70,12 @@ query getPromotion($input: PromotionQueryInput) {
       }
       createdAt
       updatedAt
+      coupon {
+        _id
+        name
+        code
+        canUseInStore
+      }
   }
 }
 

--- a/src/types/coupons.ts
+++ b/src/types/coupons.ts
@@ -1,10 +1,11 @@
 import { Coupon as APICoupon } from "@graphql/generates";
 
 
-export type CouponCreateInput = {
+export type CouponInput = {
   code: string
   name: string
   canUseInStore: boolean
+  _id?: string
 }
 
 export type Coupon = APICoupon

--- a/src/types/coupons.ts
+++ b/src/types/coupons.ts
@@ -6,6 +6,7 @@ export type CouponInput = {
   name: string
   canUseInStore: boolean
   _id?: string
+  maxUsageTimesPerUser: number
 }
 
 export type Coupon = APICoupon

--- a/src/types/coupons.ts
+++ b/src/types/coupons.ts
@@ -1,0 +1,10 @@
+import { Coupon as APICoupon } from "@graphql/generates";
+
+
+export type CouponCreateInput = {
+  code: string
+  name: string
+  canUseInStore: boolean
+}
+
+export type Coupon = APICoupon

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -62,6 +62,7 @@ export type OffersTriggerParameters = {
 export type CouponsTriggerParameters = {
   name: string
   couponCode: string
+  canUseInStore: boolean
 }
 
 export type Trigger<Key extends TriggerKeys = TriggerKeys.Offers> = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -61,7 +61,7 @@ export type OffersTriggerParameters = {
 
 export type CouponsTriggerParameters = {
   name: string
-  couponCode: string
+  code: string
   canUseInStore: boolean
 }
 

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -17,12 +17,13 @@ export enum TriggerKeys {
 export enum CalculationType {
   Percentage = "percentage",
   Fixed = "fixed",
-  Flat = "flat"
+  Flat = "flat",
 }
 
 export enum TriggerType {
   ItemAmount = "totalItemAmount",
-  ItemCount = "totalItemCount"
+  ItemCount = "totalItemCount",
+  CouponStandard = "couponStandard"
 }
 
 export enum Stackability {
@@ -65,7 +66,7 @@ export type CouponsTriggerParameters = {
 
 export type Trigger<Key extends TriggerKeys = TriggerKeys.Offers> = {
   triggerKey: Key
-  triggerParameters?: Key extends TriggerKeys.Offers ? OffersTriggerParameters : CouponsTriggerParameters
+  triggerParameters: Key extends TriggerKeys.Offers ? OffersTriggerParameters | undefined : CouponsTriggerParameters
 }
 
 export type Action = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -63,6 +63,7 @@ export type CouponsTriggerParameters = {
   name: string
   code: string
   canUseInStore: boolean
+  _id: string
 }
 
 export type Trigger<Key extends TriggerKeys = TriggerKeys.Offers> = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -9,6 +9,11 @@ export enum PromotionType {
   ShippingDiscount = "shipping-discount"
 }
 
+export enum TriggerKeys {
+  Offers = "offers",
+  Coupons = "coupons",
+}
+
 export enum CalculationType {
   Percentage = "percentage",
   Fixed = "fixed",
@@ -39,21 +44,28 @@ export type Rule = {
   }
 }
 
-export type Trigger = {
-  triggerKey: string
-  triggerParameters?: {
-    name: string
-    conditions: {
-      all: {
-        fact: string
-        operator: string
-        value: number
-        triggerType?: string
-      }[]
-    }
-    inclusionRules?: Rule
-    exclusionRules?: Rule
+export type OffersTriggerParameters = {
+  name: string
+  conditions: {
+    all: {
+      fact: string
+      operator: string
+      value: number
+      triggerType?: string
+    }[]
   }
+  inclusionRules?: Rule
+  exclusionRules?: Rule
+}
+
+export type CouponsTriggerParameters = {
+  name: string
+  couponCode: string
+}
+
+export type Trigger<Key extends TriggerKeys = TriggerKeys.Offers> = {
+  triggerKey: Key
+  triggerParameters?: Key extends TriggerKeys.Offers ? OffersTriggerParameters : CouponsTriggerParameters
 }
 
 export type Action = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -15,6 +15,11 @@ export enum CalculationType {
   Flat = "flat"
 }
 
+export enum TriggerType {
+  ItemAmount = "totalItemAmount",
+  ItemCount = "totalItemCount"
+}
+
 export enum Stackability {
   None = "none",
   All = "all"

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -64,6 +64,7 @@ export type CouponsTriggerParameters = {
   code: string
   canUseInStore: boolean
   _id: string
+  maxUsageTimesPerUser: number
 }
 
 export type Trigger<Key extends TriggerKeys = TriggerKeys.Offers> = {

--- a/src/types/promotions.ts
+++ b/src/types/promotions.ts
@@ -26,11 +26,6 @@ export enum TriggerType {
   CouponStandard = "couponStandard"
 }
 
-export enum TriggerType {
-  ItemAmount = "totalItemAmount",
-  ItemCount = "totalItemCount"
-}
-
 export enum Stackability {
   None = "none",
   All = "all"


### PR DESCRIPTION
Resolves #142, #145, #144, #146

Testing Instructions:
- Use branch `feat/coupons` on API for testing
- Start the app and login with a valid account
- Navigate to Promotions
- Click on one promotion row to go to a Promotion details page
- Scroll down to Promotion Builder section
- Select trigger `Coupon is used (Standard)` option

<img width="1516" alt="Screenshot 2023-01-17 at 13 15 40" src="https://user-images.githubusercontent.com/33818318/212823642-a933a4c8-ba87-43ec-8073-6d68c342edfd.png">

<img width="1506" alt="Screenshot 2023-01-17 at 13 16 12" src="https://user-images.githubusercontent.com/33818318/212823632-aeb0dbb9-e496-473e-aba8-bff255b9ffb6.png">
<img width="1507" alt="Screenshot 2023-01-17 at 13 15 51" src="https://user-images.githubusercontent.com/33818318/212823638-19abf44c-d521-46b7-bb15-b38c7f8e6a6d.png">

