### PR TITLE
As an operator I want to set start and end times for my promotion, in addition to start and end dates

### DIFF
--- a/src/components/DateTimePickerField/DateTimePickerField.tsx
+++ b/src/components/DateTimePickerField/DateTimePickerField.tsx
@@ -1,0 +1,54 @@
+import { DateTimePicker, DateTimePickerProps } from "@mui/x-date-pickers/DateTimePicker";
+import { FieldProps, getIn } from "formik";
+
+import { InputWithLabel } from "@components/TextField";
+
+type DateTimePickerFieldProps = DateTimePickerProps<unknown, Date> & FieldProps
+
+export const DEFAULT_DATE_TIME_FORMAT = "MM/dd/yyyy KK:mm aa";
+export const DateTimePickerField = ({
+  field,
+  form: { isSubmitting, setFieldValue, errors },
+  onChange,
+  disabled,
+  renderInput,
+  onAccept,
+  inputFormat = DEFAULT_DATE_TIME_FORMAT,
+  ...props
+}: DateTimePickerFieldProps) => {
+  const {
+    onChange: fieldOnChange,
+    onBlur: fieldOnBlur,
+    multiple: _multiple,
+    ...restFieldProps
+  } = field;
+
+  const fieldError = getIn(errors, restFieldProps.name) as string;
+
+  const helperText = fieldError ?? undefined;
+
+  const _onChange =
+    onChange ?? ((value) => setFieldValue(restFieldProps.name, value));
+
+  const _onAccept = (value: Date | null) => {
+    onAccept?.(value) ?? setFieldValue(restFieldProps.name, value);
+  };
+
+  return (
+    <DateTimePicker
+      {...props}
+      {...restFieldProps}
+      inputFormat={inputFormat}
+      disabled={disabled ?? isSubmitting}
+      onChange={_onChange}
+      onAccept={_onAccept}
+      renderInput={({ inputRef, ...params }) =>
+        <InputWithLabel
+          {...params}
+          ref={inputRef}
+          error={!!helperText}
+          helperText={helperText}
+        />}
+    />
+  );
+};

--- a/src/components/DateTimePickerField/index.tsx
+++ b/src/components/DateTimePickerField/index.tsx
@@ -1,0 +1,1 @@
+export * from "./DateTimePickerField";

--- a/src/pages/Customers/Customers.test.tsx
+++ b/src/pages/Customers/Customers.test.tsx
@@ -22,7 +22,7 @@ describe("Customers", () => {
       expect(screen.getByText(formatDate(customer.createdAt))).toBeInTheDocument();
     });
     expect(screen.getByRole("columnheader", { name: "Registered" })).toHaveAttribute("aria-sort", "ascending");
-    userEvent.click(screen.getByText("Registered"));
+    await userEvent.click(screen.getByText("Registered"));
     await waitFor(() => {
       expect(screen.getByRole("columnheader", { name: "Registered" })).toHaveAttribute("aria-sort", "descending");
     });

--- a/src/pages/Promotions/Details/AvailableDateField.tsx
+++ b/src/pages/Promotions/Details/AvailableDateField.tsx
@@ -1,10 +1,9 @@
 import Stack from "@mui/material/Stack";
 import { Field, useFormikContext } from "formik";
-import { format, isBefore } from "date-fns";
+import { isBefore } from "date-fns";
 
-import { DatePickerField } from "@components/DatePickerField";
-import { DATE_FORMAT } from "../constants";
 import { Promotion } from "types/promotions";
+import { DateTimePickerField } from "@components/DateTimePickerField";
 
 type AvailableDateFieldProps = {
   disabled?: boolean
@@ -13,7 +12,7 @@ export const AvailableDateField = ({ disabled }: AvailableDateFieldProps) => {
   const { setFieldValue, values } = useFormikContext<Promotion>();
 
   const onStartDateAccept = (value: Date | null) => {
-    setFieldValue("startDate", value ? format(value, DATE_FORMAT) : null);
+    setFieldValue("startDate", value);
     if (value && isBefore(new Date(values.endDate), new Date(value))) {
       setFieldValue("endDate", null);
     }
@@ -23,17 +22,15 @@ export const AvailableDateField = ({ disabled }: AvailableDateFieldProps) => {
     <Stack direction="row" gap={2} mt={1} position="relative" sx={{ width: { md: "50%", xs: "100%" } }}>
       <Field
         name="startDate"
-        component={DatePickerField}
+        component={DateTimePickerField}
         label="Available From"
-        inputFormat={DATE_FORMAT}
         onAccept={onStartDateAccept}
         disabled={disabled}
       />
       <Field
         name="endDate"
-        component={DatePickerField}
+        component={DateTimePickerField}
         label="Available To"
-        inputFormat={DATE_FORMAT}
         minDate={values.startDate}
       />
     </Stack>

--- a/src/pages/Promotions/Details/AvailableDateField.tsx
+++ b/src/pages/Promotions/Details/AvailableDateField.tsx
@@ -19,7 +19,7 @@ export const AvailableDateField = ({ disabled }: AvailableDateFieldProps) => {
   };
 
   return (
-    <Stack direction="row" gap={2} mt={1} position="relative" sx={{ width: { md: "50%", xs: "100%" } }}>
+    <Stack gap={2} mt={1} position="relative" sx={{ width: { md: "fit-content", xs: "100%" }, flexDirection: { md: "row", xs: "column" } }}>
       <Field
         name="startDate"
         component={DateTimePickerField}

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -33,7 +33,7 @@ describe("Promotion Details", () => {
     expect(screen.queryByText("Add Action")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add Trigger" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Discount Value")).toHaveValue(promotion.actions[0].actionParameters?.discountValue);
-    expect(screen.getByLabelText("Stack All")).toBeInTheDocument();
+    expect(screen.getByLabelText("Stack with Any")).toBeInTheDocument();
     expect(screen.getByLabelText("Available From")).toHaveValue(format(promotion.startDate, DEFAULT_DATE_TIME_FORMAT));
     expect(screen.getByLabelText("Available To")).toHaveValue(format(promotion.endDate, DEFAULT_DATE_TIME_FORMAT));
     expect(screen.getByLabelText("Checkout Label")).toHaveValue(promotion.label);

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -5,7 +5,7 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 
 import { AppLayout } from "@containers/Layouts";
-import { renderWithProviders, screen, userEvent, waitForElementToBeRemoved, within } from "@utils/testUtils";
+import { renderWithProviders, screen, userEvent, waitFor, waitForElementToBeRemoved, within } from "@utils/testUtils";
 import { DEFAULT_DATE_TIME_FORMAT } from "@components/DateTimePickerField";
 
 import PromotionDetails from ".";

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -5,8 +5,8 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 
 import { AppLayout } from "@containers/Layouts";
-import { renderWithProviders, screen, userEvent, waitFor, waitForElementToBeRemoved, within } from "@utils/testUtils";
-import { DATE_FORMAT } from "../constants";
+import { renderWithProviders, screen, userEvent, waitForElementToBeRemoved, within } from "@utils/testUtils";
+import { DEFAULT_DATE_TIME_FORMAT } from "@components/DateTimePickerField";
 
 import PromotionDetails from ".";
 
@@ -33,9 +33,9 @@ describe("Promotion Details", () => {
     expect(screen.queryByText("Add Action")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add Trigger" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Discount Value")).toHaveValue(promotion.actions[0].actionParameters?.discountValue);
-    expect(screen.getByLabelText("Stack with Any")).toBeInTheDocument();
-    expect(screen.getByLabelText("Available From")).toHaveValue(format(promotion.startDate, DATE_FORMAT));
-    expect(screen.getByLabelText("Available To")).toHaveValue(format(promotion.endDate, DATE_FORMAT));
+    expect(screen.getByLabelText("Stack All")).toBeInTheDocument();
+    expect(screen.getByLabelText("Available From")).toHaveValue(format(promotion.startDate, DEFAULT_DATE_TIME_FORMAT));
+    expect(screen.getByLabelText("Available To")).toHaveValue(format(promotion.endDate, DEFAULT_DATE_TIME_FORMAT));
     expect(screen.getByLabelText("Checkout Label")).toHaveValue(promotion.label);
   }, 50000);
 


### PR DESCRIPTION
Resolves #161 

Testing Instructions:
- Start the app and login with a valid account
- Navigate to Promotions
- Click on one promotion row to go to a Promotion details page
- Scroll down to `Promotion Scheduling` section
- Select start date and time
<img width="810" alt="Screenshot 2023-01-13 at 17 09 33" src="https://user-images.githubusercontent.com/33818318/212294390-bdb670f6-7f15-4a60-aa17-e43690ceef0a.png">

<img width="815" alt="Screenshot 2023-01-13 at 17 09 39" src="https://user-images.githubusercontent.com/33818318/212294380-399eed4c-390c-421c-a740-02ba46b59323.png">

