### PR TITLE
As an operator when I enter a value for a Condition I want that value entered in the field when I click into another area of the UI so I don't have to click Enter after each value

### DIFF
--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -48,6 +48,7 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
           freeSolo
           multiple
           options={[]}
+          autoSelect
           renderInput={(params: AutocompleteRenderInputParams) => (
             <InputWithLabel
               {...params}


### PR DESCRIPTION
Resolves #162 

Testing Instructions:
- Start the app and login with a valid account
- Navigate to Promotions
- Click on one promotion row to go to a Promotion details page
- Scroll down to the Promotion Builder section
- Click `Add Condition`
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/33818318/216542534-57431b13-8182-4d48-83e9-a4b0ec46993e.png">

- Type random value into the values field of each condition
- Click outside or Tab 
- The typed value should be auto selected
