### PR TITLE
As an operator I want to be able to filter on any custom fields that are available on the cart

### DIFF
--- a/src/components/TextField/InputWithLabel.tsx
+++ b/src/components/TextField/InputWithLabel.tsx
@@ -22,8 +22,9 @@ export const InputWithLabel = forwardRef((
     InputProps,
     inputProps,
     placeholder,
-    name
-  }: TextFieldProps,
+    name,
+    ariaLabel
+  }: TextFieldProps & {ariaLabel?: string},
   ref
 ) => {
   const labelId = useRef(uniqueId("label")).current;
@@ -45,7 +46,7 @@ export const InputWithLabel = forwardRef((
         error={error}
         disabled={disabled}
         ref={ref}
-        inputProps={{ ...inputProps, "aria-labelledby": labelId }}
+        inputProps={{ ...inputProps, "aria-labelledby": labelId, "aria-label": ariaLabel }}
         placeholder={placeholder}
         name={name}
         {...InputProps}

--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -8855,6 +8855,13 @@ export type GetViewerQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetViewerQuery = { __typename?: 'Query', viewer?: { __typename?: 'Account', _id: string, firstName?: string | null, language?: string | null, lastName?: string | null, name?: string | null, primaryEmailAddress: any, adminUIShops?: Array<{ __typename?: 'Shop', _id: string, name: string, slug?: string | null, shopType?: string | null, language: string, brandAssets?: { __typename?: 'ShopBrandAssets', navbarBrandImage?: { __typename?: 'ImageSizes', large?: string | null } | null } | null, storefrontUrls?: { __typename?: 'StorefrontUrls', storefrontHomeUrl?: string | null } | null, shopLogoUrls?: { __typename?: 'ShopLogoUrls', primaryShopLogoUrl?: string | null } | null, currency: { __typename?: 'Currency', _id: string, code: string, format: string, symbol: string } } | null> | null, groups?: { __typename?: 'GroupConnection', nodes?: Array<{ __typename?: 'Group', _id: string, name: string, permissions?: Array<string | null> | null } | null> | null } | null } | null };
 
+export type GetIntrospectSchemaQueryVariables = Exact<{
+  schemaName: Scalars['String'];
+}>;
+
+
+export type GetIntrospectSchemaQuery = { __typename?: 'Query', introspectSchema: { __typename?: 'IntrospectSchemaPayload', schemaName: string, schema?: any | null } };
+
 export type CreateShopMutationVariables = Exact<{
   input: CreateShopInput;
 }>;
@@ -9410,6 +9417,28 @@ export const useGetViewerQuery = <
     useQuery<GetViewerQuery, TError, TData>(
       variables === undefined ? ['getViewer'] : ['getViewer', variables],
       fetcher<GetViewerQuery, GetViewerQueryVariables>(client, GetViewerDocument, variables, headers),
+      options
+    );
+export const GetIntrospectSchemaDocument = `
+    query getIntrospectSchema($schemaName: String!) {
+  introspectSchema(schemaName: $schemaName) {
+    schemaName
+    schema
+  }
+}
+    `;
+export const useGetIntrospectSchemaQuery = <
+      TData = GetIntrospectSchemaQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: GetIntrospectSchemaQueryVariables,
+      options?: UseQueryOptions<GetIntrospectSchemaQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
+    useQuery<GetIntrospectSchemaQuery, TError, TData>(
+      ['getIntrospectSchema', variables],
+      fetcher<GetIntrospectSchemaQuery, GetIntrospectSchemaQueryVariables>(client, GetIntrospectSchemaDocument, variables, headers),
       options
     );
 export const CreateShopDocument = `

--- a/src/hooks/useIntrospectSchema/index.ts
+++ b/src/hooks/useIntrospectSchema/index.ts
@@ -36,5 +36,5 @@ export const useIntrospectSchema = ({ schemaName, filterFn, enabled }:
     return normalizeSchemaProperties({ schemaProperties: properties, filterFn });
   }, [data, filterFn]);
 
-  return { schemaProperties, originalSchema: schemaProperties, isLoading };
+  return { schemaProperties, originalSchema: data?.introspectSchema.schema.properties, isLoading };
 };

--- a/src/hooks/useIntrospectSchema/index.ts
+++ b/src/hooks/useIntrospectSchema/index.ts
@@ -1,11 +1,24 @@
 import { startCase } from "lodash-es";
 
+import { SelectOptionType } from "types/common";
 import { useGetIntrospectSchemaQuery } from "@graphql/generates";
 import { client } from "@graphql/graphql-request-client";
-import { FieldProperty, SchemaProperties } from "types/schema";
+import { FieldProperty, SchemaProperties, Type } from "types/schema";
 
-const normalizeSchemaProperties = (schemaProperties: SchemaProperties, filterFn?: (property: FieldProperty) => boolean) => {
-  const normalizedResults = Object.entries(schemaProperties).map(([field, property]) => ({ label: startCase(field), value: property.path, ...property }));
+type MergedOptionType = SelectOptionType & FieldProperty
+
+const normalizeSchemaProperties = ({ schemaProperties, filterFn, prependFieldName }:
+  { schemaProperties: SchemaProperties,
+    filterFn?: (property: MergedOptionType) => boolean,
+    prependFieldName?: string
+  }) : MergedOptionType[] => {
+  const normalizedResults = Object.entries(schemaProperties).flatMap(([field, property]) => {
+    if (property.type === Type.Object && Object.keys((property as FieldProperty<Type.Object>).properties).length) {
+      const objectNestedProperties = property.properties as SchemaProperties;
+      return normalizeSchemaProperties({ schemaProperties: objectNestedProperties, filterFn, prependFieldName: field });
+    }
+    return [{ label: startCase(prependFieldName ? `${prependFieldName} ${field}` : field), value: property.path, ...property }];
+  });
 
   return filterFn ? normalizedResults.filter(filterFn) : normalizedResults;
 };
@@ -14,5 +27,5 @@ export const useIntrospectSchema = ({ schemaName, filterFn }:{schemaName: string
   const { data, isLoading } = useGetIntrospectSchemaQuery(client, { schemaName });
   const schemaProperties: SchemaProperties = data?.introspectSchema.schema.properties;
 
-  return { schemaProperties: schemaProperties ? normalizeSchemaProperties(schemaProperties, filterFn) : [], originalSchema: schemaProperties, isLoading };
+  return { schemaProperties: schemaProperties ? normalizeSchemaProperties({ schemaProperties, filterFn }) : [], originalSchema: schemaProperties, isLoading };
 };

--- a/src/hooks/useIntrospectSchema/index.ts
+++ b/src/hooks/useIntrospectSchema/index.ts
@@ -21,6 +21,9 @@ const normalizeSchemaProperties = ({ schemaProperties = {}, filterFn, prependFie
     if (isObjectType(fieldProperty) && Object.keys(fieldProperty.properties).length) {
       return normalizeSchemaProperties({ schemaProperties: fieldProperty.properties, filterFn, prependFieldName: field });
     }
+    if (isArrayType(fieldProperty) && isObjectType(fieldProperty.items[0])) {
+      return normalizeSchemaProperties({ schemaProperties: fieldProperty.items[0].properties, filterFn, prependFieldName: field });
+    }
     return [{ label: startCase(prependFieldName ? `${prependFieldName} ${field}` : field), value: fieldProperty.path, ...fieldProperty }];
   });
 

--- a/src/hooks/useIntrospectSchema/index.ts
+++ b/src/hooks/useIntrospectSchema/index.ts
@@ -1,0 +1,18 @@
+import { startCase } from "lodash-es";
+
+import { useGetIntrospectSchemaQuery } from "@graphql/generates";
+import { client } from "@graphql/graphql-request-client";
+import { FieldProperty, SchemaProperties } from "types/schema";
+
+const normalizeSchemaProperties = (schemaProperties: SchemaProperties, filterFn?: (property: FieldProperty) => boolean) => {
+  const normalizedResults = Object.entries(schemaProperties).map(([field, property]) => ({ label: startCase(field), value: property.path, ...property }));
+
+  return filterFn ? normalizedResults.filter(filterFn) : normalizedResults;
+};
+
+export const useIntrospectSchema = ({ schemaName, filterFn }:{schemaName: string, filterFn?: (property: FieldProperty) => boolean}) => {
+  const { data, isLoading } = useGetIntrospectSchemaQuery(client, { schemaName });
+  const schemaProperties: SchemaProperties = data?.introspectSchema.schema.properties;
+
+  return { schemaProperties: schemaProperties ? normalizeSchemaProperties(schemaProperties, filterFn) : [], originalSchema: schemaProperties, isLoading };
+};

--- a/src/hooks/useIntrospectSchema/introspectSchema.graphql
+++ b/src/hooks/useIntrospectSchema/introspectSchema.graphql
@@ -1,0 +1,6 @@
+query getIntrospectSchema($schemaName: String!) {
+  introspectSchema(schemaName: $schemaName) {
+    schemaName
+    schema
+  }
+}

--- a/src/hooks/useIntrospectSchema/useIntrospectSchema.test.tsx
+++ b/src/hooks/useIntrospectSchema/useIntrospectSchema.test.tsx
@@ -17,7 +17,9 @@ describe("useIntrospectSchema", () => {
         { label: "Price Type", value: "$.priceType", ...cartItemProperties.priceType },
         { label: "Product Tag Ids", value: "$.productTagIds", ...cartItemProperties.productTagIds },
         { label: "Parcel Containers", value: "$.parcel.containers", ...cartItemProperties.parcel.properties.containers },
-        { label: "Parcel Length", value: "$.parcel.length", ...cartItemProperties.parcel.properties.length }
+        { label: "Parcel Length", value: "$.parcel.length", ...cartItemProperties.parcel.properties.length },
+        { label: "Attributes Label", value: "$.attributes.[0].label", ...cartItemProperties.attributes.items[0].properties.label },
+        { label: "Attributes Value", value: "$.attributes.[0].value", ...cartItemProperties.attributes.items[0].properties.value }
       ]);
     });
   });

--- a/src/hooks/useIntrospectSchema/useIntrospectSchema.test.tsx
+++ b/src/hooks/useIntrospectSchema/useIntrospectSchema.test.tsx
@@ -1,0 +1,24 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { cartItemProperties } from "@mocks/handlers/introspectSchemaHandlers";
+
+import { renderHook, waitFor } from "@utils/testUtils";
+
+import { useIntrospectSchema } from ".";
+
+const client = new QueryClient();
+const wrapper = ({ children }: {children: JSX.Element}) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+
+describe("useIntrospectSchema", () => {
+  it("should return normalize schema data", async () => {
+    const { result } = renderHook(() => useIntrospectSchema({ schemaName: "CartItem", enabled: true }), { wrapper });
+    await waitFor(() => {
+      expect(result.current.schemaProperties).toEqual([
+        { label: "Product Id", value: "$.productId", ...cartItemProperties.productId },
+        { label: "Price Type", value: "$.priceType", ...cartItemProperties.priceType },
+        { label: "Product Tag Ids", value: "$.productTagIds", ...cartItemProperties.productTagIds },
+        { label: "Parcel Containers", value: "$.parcel.containers", ...cartItemProperties.parcel.properties.containers },
+        { label: "Parcel Length", value: "$.parcel.length", ...cartItemProperties.parcel.properties.length }
+      ]);
+    });
+  });
+});

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -6,8 +6,9 @@ import { handlers as transactionalEmailHandlers } from "./transactionalEmailHand
 import { handlers as checkoutSettingsHandlers } from "./checkoutSettingsHandlers";
 import { handlers as customersHandlersHandlers } from "./customersHandlers";
 import { handlers as promotionsHandlersHandlers } from "./promotionsHandlers";
+import { handlers as introspectSchemaHandlers } from "./introspectSchemaHandlers";
 
 export const handlers = [
   ...shippingMethodsHandlers, ...accountHandlers, ...userHandlers, ...shopSettingsHandlers, ...transactionalEmailHandlers, ...checkoutSettingsHandlers,
-  ...customersHandlersHandlers, ...promotionsHandlersHandlers
+  ...customersHandlersHandlers, ...promotionsHandlersHandlers, ...introspectSchemaHandlers
 ];

--- a/src/mocks/handlers/introspectSchemaHandlers.ts
+++ b/src/mocks/handlers/introspectSchemaHandlers.ts
@@ -1,6 +1,6 @@
 import { graphql } from "msw";
 
-const mockCartItemSchema = {
+export const mockCartItemSchema = {
   schema: {
     properties: {
       productId: {
@@ -26,12 +26,29 @@ const mockCartItemSchema = {
         ],
         additionalItems: false,
         path: "$.productTagIds"
+      },
+      parcel: {
+        type: "object",
+        properties: {
+          containers: {
+            type: "string",
+            path: "$.parcel.containers"
+          },
+          length: {
+            type: "number",
+            path: "$.parcel.length"
+          }
+        },
+        required: [],
+        additionalProperties: false,
+        path: "$.parcel"
       }
     }
   },
   schemaName: "CartItem"
 };
 
+export const cartItemProperties = mockCartItemSchema.schema.properties;
 const getIntrospectSchemaHandler = graphql.query("getIntrospectSchema", (req, res, ctx) =>
   res(ctx.data({ introspectSchema: mockCartItemSchema })));
 

--- a/src/mocks/handlers/introspectSchemaHandlers.ts
+++ b/src/mocks/handlers/introspectSchemaHandlers.ts
@@ -42,6 +42,31 @@ export const mockCartItemSchema = {
         required: [],
         additionalProperties: false,
         path: "$.parcel"
+      },
+      attributes: {
+        type: "array",
+        items: [
+          {
+            type: "object",
+            properties: {
+              label: {
+                type: "string",
+                path: "$.attributes.[0].label"
+              },
+              value: {
+                type: "string",
+                path: "$.attributes.[0].value"
+              }
+            },
+            required: [
+              "label"
+            ],
+            additionalProperties: false,
+            path: "$.attributes.[0]"
+          }
+        ],
+        additionalItems: false,
+        path: "$.attributes"
       }
     }
   },

--- a/src/mocks/handlers/introspectSchemaHandlers.ts
+++ b/src/mocks/handlers/introspectSchemaHandlers.ts
@@ -1,0 +1,41 @@
+import { graphql } from "msw";
+
+const mockCartItemSchema = {
+  schema: {
+    properties: {
+      productId: {
+        type: "string",
+        path: "$.productId"
+      },
+      priceType: {
+        type: "string",
+        enum: [
+          "full",
+          "clearance",
+          "sale"
+        ],
+        path: "$.priceType"
+      },
+      productTagIds: {
+        type: "array",
+        items: [
+          {
+            type: "string",
+            path: "$.productTagIds.[0]"
+          }
+        ],
+        additionalItems: false,
+        path: "$.productTagIds"
+      }
+    }
+  },
+  schemaName: "CartItem"
+};
+
+const getIntrospectSchemaHandler = graphql.query("getIntrospectSchema", (req, res, ctx) =>
+  res(ctx.data({ introspectSchema: mockCartItemSchema })));
+
+
+export const handlers = [
+  getIntrospectSchemaHandler
+];

--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -1,8 +1,9 @@
 import Stack from "@mui/material/Stack";
-import { FastField, Field, useFormikContext } from "formik";
+import { FastField, Field, getIn, useFormikContext } from "formik";
 import { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
 import Typography from "@mui/material/Typography";
-import { memo, SyntheticEvent } from "react";
+import { SyntheticEvent, useRef } from "react";
+import * as Yup from "yup";
 
 import { SelectField } from "@components/SelectField";
 import { CONDITION_OPERATORS, OPERATOR_OPTIONS } from "../constants";
@@ -11,6 +12,7 @@ import { AutocompleteField } from "@components/AutocompleteField";
 import { FieldPropertySelectOption } from "@hooks/useIntrospectSchema";
 import { Promotion } from "types/promotions";
 import { SelectOptionType } from "types/common";
+import { Type } from "types/schema";
 
 type ConditionFieldProps = {
   name: string
@@ -20,15 +22,44 @@ type ConditionFieldProps = {
   isLoadingSchema: boolean
 }
 
-export const ConditionField = memo(({ name, index, operator, isLoadingSchema, schemaProperties }: ConditionFieldProps) => {
-  const { setFieldValue } = useFormikContext<Promotion>();
-  const onPathChange = (_: SyntheticEvent, selectedOption: SelectOptionType | null) => {
+
+export const ConditionField = ({ name, index, operator, isLoadingSchema, schemaProperties }: ConditionFieldProps) => {
+  const { setFieldValue, values } = useFormikContext<Promotion>();
+
+  const selectedProperty = useRef(schemaProperties.find((option) => option.value === getIn(values, `${name}.path`)) || null);
+  const availableValueOptions = useRef<string[]>([]);
+
+  const onPathChange = (_: SyntheticEvent, selectedOption: FieldPropertySelectOption | null) => {
     setFieldValue(`${name}.path`, selectedOption ? selectedOption.value : null);
+    selectedProperty.current = selectedOption;
+
+    if (selectedOption?.type === Type.Boolean) {
+      availableValueOptions.current = ["true", "false"];
+    } else if (selectedOption?.enum) {
+      availableValueOptions.current = selectedOption.enum;
+    }
   };
 
-  const getOptionLabel = (optionValue: string | SelectOptionType) => {
+  const getOptionLabel = (optionValue: string | FieldPropertySelectOption) => {
     if (typeof optionValue === "string") return schemaProperties.find((option) => option.value === optionValue)?.label || "";
     return optionValue.label;
+  };
+
+  const validateConditionValue = (selectedValues: string[]) => {
+    let error;
+    if (selectedProperty.current?.type === Type.Number || selectedProperty.current?.type === Type.Integer) {
+      if (selectedValues.some((value) => !Yup.number().isValidSync(value))) {
+        error = "Please enter number values";
+      }
+      if (typeof selectedProperty.current?.minimum !== "undefined"
+      && selectedValues.some((value) => !Yup.number().min(Number(selectedProperty.current?.minimum)).isValidSync(value))) {
+        error = `All values must be greater than or equal to ${selectedProperty.current.minimum}`;
+      }
+    }
+    if (selectedProperty.current?.format === Type.DateTime && selectedValues.some((value) => !Yup.date().isValidSync(value))) {
+      error = "Please enter valid date time values";
+    }
+    return error;
   };
 
   return (
@@ -66,17 +97,18 @@ export const ConditionField = memo(({ name, index, operator, isLoadingSchema, sc
           placeholder="Operator"
           displayEmpty
         />
-        <FastField
+        <Field
           component={AutocompleteField}
+          validate={validateConditionValue}
           name={`${name}.value`}
-          freeSolo
+          freeSolo={!availableValueOptions.current.length}
           multiple
-          options={[]}
+          options={availableValueOptions.current}
           autoSelect
           renderInput={(params: AutocompleteRenderInputParams) => (
             <InputWithLabel
               {...params}
-              name="value"
+              name={`${name}.value`}
               placeholder="Enter Values"
               hiddenLabel
             />
@@ -85,5 +117,4 @@ export const ConditionField = memo(({ name, index, operator, isLoadingSchema, sc
       </Stack>
     </Stack>
   );
-});
-
+};

--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -8,8 +8,7 @@ import { SelectField } from "@components/SelectField";
 import { CONDITION_OPERATORS, OPERATOR_OPTIONS } from "../constants";
 import { InputWithLabel } from "@components/TextField";
 import { AutocompleteField } from "@components/AutocompleteField";
-import { useIntrospectSchema } from "@hooks/useIntrospectSchema";
-import { Type } from "types/schema";
+import { FieldPropertySelectOption } from "@hooks/useIntrospectSchema";
 import { Promotion } from "types/promotions";
 import { SelectOptionType } from "types/common";
 
@@ -17,10 +16,11 @@ type ConditionFieldProps = {
   name: string
   index: number
   operator: string
+  schemaProperties: FieldPropertySelectOption[]
+  isLoadingSchema: boolean
 }
 
-export const ConditionField = memo(({ name, index, operator }: ConditionFieldProps) => {
-  const { schemaProperties, isLoading } = useIntrospectSchema({ schemaName: "CartItem", filterFn: ({ type }) => type !== Type.Array });
+export const ConditionField = memo(({ name, index, operator, isLoadingSchema, schemaProperties }: ConditionFieldProps) => {
   const { setFieldValue } = useFormikContext<Promotion>();
   const onPathChange = (_: SyntheticEvent, selectedOption: SelectOptionType | null) => {
     setFieldValue(`${name}.path`, selectedOption ? selectedOption.value : null);
@@ -43,7 +43,7 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
           name={`${name}.path`}
           component={AutocompleteField}
           options={schemaProperties}
-          loading={isLoading}
+          loading={isLoadingSchema}
           isOptionEqualToValue={(option: SelectOptionType, value: string) => (value ? option.value === value : false)}
           onChange={onPathChange}
           getOptionLabel={getOptionLabel}

--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -1,15 +1,17 @@
 import Stack from "@mui/material/Stack";
-import { FastField, Field } from "formik";
+import { FastField, Field, useFormikContext } from "formik";
 import { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
 import Typography from "@mui/material/Typography";
-import { memo } from "react";
+import { memo, SyntheticEvent } from "react";
 
 import { SelectField } from "@components/SelectField";
 import { CONDITION_OPERATORS, OPERATOR_OPTIONS } from "../constants";
 import { InputWithLabel } from "@components/TextField";
-import { AutocompleteField, isOptionEqualToValue } from "@components/AutocompleteField";
+import { AutocompleteField } from "@components/AutocompleteField";
 import { useIntrospectSchema } from "@hooks/useIntrospectSchema";
 import { Type } from "types/schema";
+import { Promotion } from "types/promotions";
+import { SelectOptionType } from "types/common";
 
 type ConditionFieldProps = {
   name: string
@@ -19,6 +21,11 @@ type ConditionFieldProps = {
 
 export const ConditionField = memo(({ name, index, operator }: ConditionFieldProps) => {
   const { schemaProperties, isLoading } = useIntrospectSchema({ schemaName: "CartItem", filterFn: ({ type }) => type !== Type.Array });
+  const { setFieldValue } = useFormikContext<Promotion>();
+
+  const onPathChange = (_: SyntheticEvent, selectedOption: SelectOptionType | null) => {
+    setFieldValue(`${name}.path`, selectedOption ? selectedOption.value : null);
+  };
 
   return (
     <Stack direction="row" gap={1} alignItems="center" pl={1}>
@@ -33,7 +40,12 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
           component={AutocompleteField}
           options={schemaProperties}
           loading={isLoading}
-          isOptionEqualToValue={isOptionEqualToValue}
+          isOptionEqualToValue={(option: SelectOptionType, value: string) => option.value === value}
+          onChange={onPathChange}
+          getOptionLabel={(optionValue: string | SelectOptionType) => {
+            if (typeof optionValue === "string") return schemaProperties.find((option) => option.value === optionValue)?.label || "Unknown";
+            return optionValue.label;
+          }}
           renderInput={(params: AutocompleteRenderInputParams) => (
             <InputWithLabel
               {...params}

--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -1,13 +1,15 @@
 import Stack from "@mui/material/Stack";
-import { FastField } from "formik";
+import { FastField, Field } from "formik";
 import { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
 import Typography from "@mui/material/Typography";
 import { memo } from "react";
 
 import { SelectField } from "@components/SelectField";
-import { CONDITION_OPERATORS, CONDITION_PROPERTIES_OPTIONS, OPERATOR_OPTIONS } from "../constants";
+import { CONDITION_OPERATORS, OPERATOR_OPTIONS } from "../constants";
 import { InputWithLabel } from "@components/TextField";
-import { AutocompleteField } from "@components/AutocompleteField";
+import { AutocompleteField, isOptionEqualToValue } from "@components/AutocompleteField";
+import { useIntrospectSchema } from "@hooks/useIntrospectSchema";
+import { Type } from "types/schema";
 
 type ConditionFieldProps = {
   name: string
@@ -15,8 +17,10 @@ type ConditionFieldProps = {
   operator: string
 }
 
-export const ConditionField = memo(({ name, index, operator }: ConditionFieldProps) =>
-  (
+export const ConditionField = memo(({ name, index, operator }: ConditionFieldProps) => {
+  const { schemaProperties, isLoading } = useIntrospectSchema({ schemaName: "CartItem", filterFn: ({ type }) => type !== Type.Array });
+
+  return (
     <Stack direction="row" gap={1} alignItems="center" pl={1}>
       <Stack flexBasis="30px">
         {index > 0 ? <Typography color="grey.700" variant="caption">
@@ -24,14 +28,21 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
         </Typography> : null}
       </Stack>
       <Stack sx={{ flexDirection: { sm: "column", md: "row" }, gap: { sm: 0, md: 3 } }} flexGrow={1}>
-        <FastField
-          component={SelectField}
+        <Field
           name={`${name}.path`}
-          placeholder="Property"
-          ariaLabel="Property"
-          hiddenLabel
-          options={CONDITION_PROPERTIES_OPTIONS}
-          displayEmpty
+          component={AutocompleteField}
+          options={schemaProperties}
+          loading={isLoading}
+          isOptionEqualToValue={isOptionEqualToValue}
+          renderInput={(params: AutocompleteRenderInputParams) => (
+            <InputWithLabel
+              {...params}
+              name={`${name}.path`}
+              placeholder="Property"
+              ariaLabel="Property"
+              hiddenLabel
+            />
+          )}
         />
         <FastField
           component={SelectField}
@@ -60,5 +71,6 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
         />
       </Stack>
     </Stack>
-  ));
+  );
+});
 

--- a/src/pages/Promotions/Details/ConditionField.tsx
+++ b/src/pages/Promotions/Details/ConditionField.tsx
@@ -22,9 +22,13 @@ type ConditionFieldProps = {
 export const ConditionField = memo(({ name, index, operator }: ConditionFieldProps) => {
   const { schemaProperties, isLoading } = useIntrospectSchema({ schemaName: "CartItem", filterFn: ({ type }) => type !== Type.Array });
   const { setFieldValue } = useFormikContext<Promotion>();
-
   const onPathChange = (_: SyntheticEvent, selectedOption: SelectOptionType | null) => {
     setFieldValue(`${name}.path`, selectedOption ? selectedOption.value : null);
+  };
+
+  const getOptionLabel = (optionValue: string | SelectOptionType) => {
+    if (typeof optionValue === "string") return schemaProperties.find((option) => option.value === optionValue)?.label || "";
+    return optionValue.label;
   };
 
   return (
@@ -40,12 +44,9 @@ export const ConditionField = memo(({ name, index, operator }: ConditionFieldPro
           component={AutocompleteField}
           options={schemaProperties}
           loading={isLoading}
-          isOptionEqualToValue={(option: SelectOptionType, value: string) => option.value === value}
+          isOptionEqualToValue={(option: SelectOptionType, value: string) => (value ? option.value === value : false)}
           onChange={onPathChange}
-          getOptionLabel={(optionValue: string | SelectOptionType) => {
-            if (typeof optionValue === "string") return schemaProperties.find((option) => option.value === optionValue)?.label || "Unknown";
-            return optionValue.label;
-          }}
+          getOptionLabel={getOptionLabel}
           renderInput={(params: AutocompleteRenderInputParams) => (
             <InputWithLabel
               {...params}

--- a/src/pages/Promotions/Details/EligibleItems.tsx
+++ b/src/pages/Promotions/Details/EligibleItems.tsx
@@ -17,7 +17,7 @@ type EligibleItemsProps = {
   exclusionFieldName: string
 }
 
-const initialValue = { fact: "item", path: "", value: [], operator: "" };
+const initialValue = { fact: "item", path: null, value: [], operator: "" };
 export const EligibleItems = ({ inclusionFieldName, exclusionFieldName }: EligibleItemsProps) => {
   const { setFieldValue, values } = useFormikContext<Promotion>();
 

--- a/src/pages/Promotions/Details/PromotionDetails.test.tsx
+++ b/src/pages/Promotions/Details/PromotionDetails.test.tsx
@@ -67,7 +67,7 @@ describe("Promotion Details", () => {
     await user.type(screen.getByLabelText("Trigger Value"), "12");
     await user.click(screen.getAllByText("Add Condition")[0]);
     await user.click(screen.getByLabelText("Property"));
-    await user.click(within(screen.getByRole("listbox")).getByText("Vendor"));
+    await user.click(within(screen.getByRole("listbox")).getByText("Product Id"));
     await user.click(screen.getByLabelText("Operator"));
     await user.click(within(screen.getByRole("listbox")).getByText("Is"));
     await user.type(screen.getByPlaceholderText("Enter Values"), "value{enter}");

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -1,7 +1,10 @@
 import * as Yup from "yup";
 
 const ruleSchema = Yup.object({
-  path: Yup.string().required("This field is required"),
+  path: Yup.object({
+    value: Yup.string().required("This field is required"),
+    label: Yup.string()
+  }),
   operator: Yup.string().required("This field is required"),
   value: Yup.array().min(1, "This field must have at least 1 value").when("operator", {
     is: "equal",

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -1,10 +1,7 @@
 import * as Yup from "yup";
 
 const ruleSchema = Yup.object({
-  path: Yup.object({
-    value: Yup.string().required("This field is required"),
-    label: Yup.string()
-  }),
+  path: Yup.string().required("This field is required"),
   operator: Yup.string().required("This field is required"),
   value: Yup.array().min(1, "This field must have at least 1 value").when("operator", {
     is: "equal",

--- a/src/pages/Promotions/Details/validation.ts
+++ b/src/pages/Promotions/Details/validation.ts
@@ -1,7 +1,7 @@
 import * as Yup from "yup";
 
 const ruleSchema = Yup.object({
-  path: Yup.string().required("This field is required"),
+  path: Yup.string().required("This field is required").nullable(),
   operator: Yup.string().required("This field is required"),
   value: Yup.array().min(1, "This field must have at least 1 value").when("operator", {
     is: "equal",

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -12,7 +12,7 @@ export type FieldProperty<FieldType extends Type = Type> = {
   type: FieldType
   path: string
   format?: string
-  items: FieldProperty<FieldType>["type"] extends Type.Array ? Array<FieldProperty<FieldType>> : undefined
+  items: FieldProperty<FieldType>["type"] extends Type.Array ? Array<FieldProperty<Type>> : undefined
   properties: FieldProperty<FieldType>["type"] extends Type.Object ? {[key: string]: FieldProperty<FieldType>} : undefined
   required: string[]
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,0 +1,22 @@
+
+export enum Type {
+  String = "string",
+  Object = "object",
+  Array = "array",
+  Number = "number",
+  Boolean = "boolean",
+  Integer = "integer"
+}
+
+export type FieldProperty = {
+  type: Type
+  path: string
+  format?: string
+  items: FieldProperty["type"] extends Type.Array ? Array<FieldProperty> : undefined
+  properties: FieldProperty["type"] extends Type.Object ? {[key: string]: FieldProperty} : undefined
+  required: string[]
+}
+
+export type SchemaProperties = {
+  [key: string]: FieldProperty
+}

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -8,15 +8,15 @@ export enum Type {
   Integer = "integer"
 }
 
-export type FieldProperty = {
-  type: Type
+export type FieldProperty<FieldType extends Type = Type> = {
+  type: FieldType
   path: string
   format?: string
-  items: FieldProperty["type"] extends Type.Array ? Array<FieldProperty> : undefined
-  properties: FieldProperty["type"] extends Type.Object ? {[key: string]: FieldProperty} : undefined
+  items: FieldProperty<FieldType>["type"] extends Type.Array ? Array<FieldProperty<FieldType>> : undefined
+  properties: FieldProperty<FieldType>["type"] extends Type.Object ? {[key: string]: FieldProperty<FieldType>} : undefined
   required: string[]
 }
 
-export type SchemaProperties = {
-  [key: string]: FieldProperty
+export type SchemaProperties<FieldType extends Type = Type> = {
+  [key: string]: FieldProperty<FieldType>
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -5,7 +5,8 @@ export enum Type {
   Array = "array",
   Number = "number",
   Boolean = "boolean",
-  Integer = "integer"
+  Integer = "integer",
+  DateTime = "date-time",
 }
 
 export type FieldProperty<FieldType extends Type = Type> = {
@@ -15,6 +16,8 @@ export type FieldProperty<FieldType extends Type = Type> = {
   items: FieldProperty<FieldType>["type"] extends Type.Array ? Array<FieldProperty<Type>> : undefined
   properties: FieldProperty<FieldType>["type"] extends Type.Object ? {[key: string]: FieldProperty<FieldType>} : undefined
   required: string[]
+  enum?: string[]
+  minimum: FieldProperty<FieldType>["type"] extends (Type.Integer | Type.Number) ? number : undefined
 }
 
 export type SchemaProperties<FieldType extends Type = Type> = {


### PR DESCRIPTION
Resolves #164

Testing Instructions:
- Use branch `feat/promotions` on API for testing
- Start the app and login with a valid account
- Navigate to Promotions
- Click Actions/Create New
- Fill in all required fields
- Scroll down to Promotion Builder section
- Click Add Action
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/33818318/219300053-8cfb2f02-0ba7-447f-ac53-1df32d676408.png">
 - Click Add Condition
 - Click on `Property` field
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/33818318/219300945-9aa61306-2217-4b0e-a1e6-1695017f6f42.png">

- Data populated in the dropdown comes from the `introspectSchema` endpoint with the schema name `CartItem`.
