### PR TITLE
Should send single value when creating inclusion/exclusion rules with `equal` operator

### DIFF
--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -27,7 +27,7 @@ import { PromotionTriggers } from "./PromotionTriggers";
 import { promotionSchema } from "./validation";
 import { AvailableDateField } from "./AvailableDateField";
 import { PromotionTypeField } from "./PromotionTypeField";
-import { normalizeActionsData, normalizeTriggersData } from "./utils";
+import { formatRule, normalizeActionsData, normalizeTriggersData } from "./utils";
 
 type PromotionFormValue = {
   name: string
@@ -51,6 +51,8 @@ const formatTriggers = (triggers: Trigger[], promotionName: string) =>
     ...trigger,
     triggerParameters: {
       ...trigger.triggerParameters,
+      inclusionRules: formatRule(trigger.triggerParameters?.inclusionRules),
+      exclusionRules: formatRule(trigger.triggerParameters?.exclusionRules),
       name: trigger.triggerParameters?.name || promotionName,
       conditions: { all: getTriggerType(trigger.triggerParameters?.conditions.all) }
     }
@@ -69,6 +71,8 @@ const formatActions = (actions: Action[]): Action[] => actions.map((action) =>
     ...(action.actionParameters ? {
       actionParameters: {
         ...action.actionParameters,
+        inclusionRules: formatRule(action.actionParameters?.inclusionRules),
+        exclusionRules: formatRule(action.actionParameters?.exclusionRules),
         discountMaxUnits: action.actionParameters?.discountMaxUnits || 0,
         discountMaxValue: action.actionParameters?.discountMaxValue || 0
       }

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -1,16 +1,15 @@
-import { Action, Rule, Trigger } from "types/promotions";
+import { Action, Rule, RuleCondition, Trigger } from "types/promotions";
 import { Operator } from "../constants";
 
 
 const normalizeRuleCondition = (conditions: Rule["conditions"]) => {
-  const newAllConditions = conditions.all?.map((condition) => {
+  const normalize = (condition: RuleCondition) => {
     if (condition.operator === Operator.Equal) return { ...condition, value: condition.value[0] };
     return condition;
-  });
-  const newAnyConditions = conditions.any?.map((condition) => {
-    if (condition.operator === Operator.Equal) return { ...condition, value: condition.value[0] };
-    return condition;
-  });
+  };
+
+  const newAllConditions = conditions.all?.map(normalize);
+  const newAnyConditions = conditions.any?.map(normalize);
 
   return { all: newAllConditions, any: newAnyConditions };
 };
@@ -48,17 +47,16 @@ export const normalizeActionsData = (actions?: Action[]) => actions?.map((action
 }));
 
 export const formatRule = (rule?: Rule) => {
+  const formatFn = (condition: RuleCondition) => {
+    if (condition.operator === Operator.Equal) return { ...condition, value: !Array.isArray(condition.value) ? [condition.value] : condition.value };
+    return condition;
+  };
+
   if (rule?.conditions) {
     return {
       conditions: {
-        all: rule.conditions.all?.map((condition) => {
-          if (condition.operator === Operator.Equal) return { ...condition, value: !Array.isArray(condition.value) ? [condition.value] : condition.value };
-          return condition;
-        }),
-        any: rule.conditions.any?.map((condition) => {
-          if (condition.operator === Operator.Equal) return { ...condition, value: !Array.isArray(condition.value) ? [condition.value] : condition.value };
-          return condition;
-        })
+        all: rule.conditions.all?.map(formatFn),
+        any: rule.conditions.any?.map(formatFn)
       }
     };
   }

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -1,4 +1,20 @@
 import { Action, Rule, Trigger } from "types/promotions";
+import { Operator } from "../constants";
+
+
+const normalizeRuleCondition = (conditions: Rule["conditions"]) => {
+  const newAllConditions = conditions.all?.map((condition) => {
+    if (condition.operator === Operator.Equal) return { ...condition, value: condition.value[0] };
+    return condition;
+  });
+  const newAnyConditions = conditions.any?.map((condition) => {
+    if (condition.operator === Operator.Equal) return { ...condition, value: condition.value[0] };
+    return condition;
+  });
+
+  return { all: newAllConditions, any: newAnyConditions };
+};
+
 
 const normalizeRule = (rule?: Rule) => {
   const newRule = { ...rule };
@@ -6,7 +22,7 @@ const normalizeRule = (rule?: Rule) => {
   if (newRule.conditions?.any && !newRule.conditions.any.length) newRule.conditions.any = undefined;
   if (!newRule.conditions?.all && !newRule.conditions?.any) newRule.conditions = undefined;
 
-  return newRule.conditions ? newRule : undefined;
+  return newRule.conditions ? { conditions: normalizeRuleCondition(newRule.conditions) } : undefined;
 };
 
 export const normalizeTriggersData = (triggers?: Trigger[]) => triggers?.map((trigger) => ({
@@ -30,3 +46,22 @@ export const normalizeActionsData = (actions?: Action[]) => actions?.map((action
     exclusionRules: normalizeRule(action.actionParameters?.exclusionRules)
   }
 }));
+
+export const formatRule = (rule?: Rule) => {
+  if (rule?.conditions) {
+    return {
+      conditions: {
+        all: rule.conditions.all?.map((condition) => {
+          if (condition.operator === Operator.Equal) return { ...condition, value: !Array.isArray(condition.value) ? [condition.value] : condition.value };
+          return condition;
+        }),
+        any: rule.conditions.any?.map((condition) => {
+          if (condition.operator === Operator.Equal) return { ...condition, value: !Array.isArray(condition.value) ? [condition.value] : condition.value };
+          return condition;
+        })
+      }
+    };
+  }
+
+  return rule;
+};

--- a/src/pages/Promotions/constants.ts
+++ b/src/pages/Promotions/constants.ts
@@ -33,10 +33,14 @@ export const TRIGGER_TYPE_MAP: Record<TriggerType, SelectOptionType> = {
 
 export const TRIGGER_TYPE_OPTIONS = Object.values(TRIGGER_TYPE_MAP);
 
+export enum Operator {
+  Equal = "equal",
+  IsAnyOf = "in"
+}
 
 export const OPERATOR_OPTIONS: SelectOptionType[] = [
-  { label: "Is", value: "equal" },
-  { label: "Is Any Of", value: "in" }
+  { label: "Is", value: Operator.Equal },
+  { label: "Is Any Of", value: Operator.IsAnyOf }
 ];
 
 export const CONDITION_PROPERTIES_OPTIONS: SelectOptionType[] = [

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -368,6 +368,7 @@ const theme = createTheme(baseTheme, {
           color: color.grey[600],
           fontWeight: 400,
           borderRadius: baseTheme.shape.borderRadius,
+          margin: 2,
           svg: {
             fontSize: 12,
             fill: color.grey[600]


### PR DESCRIPTION
Resolves #192 

Testing Instructions:
- Start the app and login with a valid account
- Navigate to Promotions
- Click Actions -> Create New
- Create a promotion with an inclusion/exclusion rule
- Select `Is` Operator
<img width="2116" alt="image" src="https://user-images.githubusercontent.com/33818318/218444663-173e0506-c991-456d-8aa1-a75cf814a970.png">
Expected Inclusions rule

```

 inclusionRules:  {
    "conditions": {
        "all": [
            {
                "fact": "item",
                "path": "$.productVendor",
                "value": "EMS",
                "operator": "equal"
            }
        ]
    }
}

```
- Select `Is Any Of` Operator

```
inclusionRules: {
    "conditions": {
        "all": [
            {
                "fact": "item",
                "path": "$.productVendor",
                "value": [
                    "EMS"
                ],
                "operator": "in"
            }
        ]
    }
}
```

