### PR TITLE
As an operator I want to set my promotion type to Shipping Discount

### DIFF
--- a/src/graphql/generates.ts
+++ b/src/graphql/generates.ts
@@ -930,8 +930,10 @@ export type CartDiscount = {
   discountedItemType?: Maybe<Scalars['String']>;
   /**  The items that were discounted. Only available if `discountedItemType` is `item`. */
   discountedItems?: Maybe<Array<Maybe<CartDiscountedItem>>>;
-  /** Should this discount be applied before other discounts? */
+  /** Should this discount be applied before other item discounts? */
   neverStackWithOtherItemLevelDiscounts?: Maybe<Scalars['Boolean']>;
+  /** Should this discount be applied before other shipping discounts? */
+  neverStackWithOtherShippingDiscounts?: Maybe<Scalars['Boolean']>;
   /**  The ID of the promotion that created this discount */
   promotionId: Scalars['ID'];
 };
@@ -2806,6 +2808,8 @@ export type FulfillmentGroup = Node & {
   availableFulfillmentOptions: Array<Maybe<FulfillmentOption>>;
   /** Information needed by the fulfillment type to properly fulfill the order */
   data?: Maybe<FulfillmentData>;
+  /** The array of discounts applied to the fulfillment group. */
+  discounts?: Maybe<Array<Maybe<CartDiscount>>>;
   /** The items that are included in this fulfillment group */
   items: Array<Maybe<CartItem>>;
   /** The fulfillment method selected by a shopper for this group, with its associated price */
@@ -2828,6 +2832,8 @@ export type FulfillmentMethod = Node & {
   _id: Scalars['ID'];
   /** A carrier name */
   carrier?: Maybe<Scalars['String']>;
+  /** The total discount amount of the fulfillment method.  */
+  discount?: Maybe<Scalars['Float']>;
   /** The name of this method, for display in the user interface */
   displayName: Scalars['String'];
   /** The fulfillment types for which this method may be used. For example, `shipping` or `digital`. */
@@ -2836,6 +2842,8 @@ export type FulfillmentMethod = Node & {
   group?: Maybe<Scalars['String']>;
   /** The name of this method, a unique identifier */
   name: Scalars['String'];
+  /** The total undiscounted rate of the fulfillment method.  */
+  undiscountedRate?: Maybe<Scalars['Float']>;
 };
 
 /** A fulfillment option for a cart fulfillment group, which is a method with an associated price */

--- a/src/mocks/handlers/promotionsHandlers.ts
+++ b/src/mocks/handlers/promotionsHandlers.ts
@@ -87,4 +87,8 @@ graphql.mutation("duplicatePromotion", (req, res, ctx) =>
   res(ctx.data({ duplicatePromotion: { promotion: { _id: enabledPromotions[0]._id }, success: true } })));
 
 
-export const handlers = [getPromotionsHandler, getPromotionHandler, createPromotionHandler, updatePromotionHandler, duplicatePromotionHandler];
+const createStandardCouponHandler = graphql.mutation("createStandardCoupon", (req, res, ctx) =>
+  res(ctx.data({ createStandardCoupon: { coupon: { _id: faker.datatype.uuid() }, success: true } })));
+
+export const handlers = [getPromotionsHandler, getPromotionHandler, createPromotionHandler, updatePromotionHandler, duplicatePromotionHandler,
+  createStandardCouponHandler];

--- a/src/pages/Promotions/Details/EligibleShippingMethods.tsx
+++ b/src/pages/Promotions/Details/EligibleShippingMethods.tsx
@@ -55,7 +55,7 @@ export const EligibleShippingMethods = ({ inclusionFieldName, disabled }: Eligib
             <FieldArrayRenderer
               {...props}
               addButtonProps={{ disabled, children: "Add Shipping Method", sx: { ml: 5.7 }, hidden: get(props.form.values, inclusionFieldName, []).length > 0 }}
-              initialValue={{ fact: "shipping", path: "$.shippingMethod.name", value: [], operator: "in" }}
+              initialValue={{ fact: "shipping", path: "$.shipmentMethod.name", value: [], operator: "in" }}
               renderFieldItem={() => (
                 <Stack pl={5.7}>
                   <Field

--- a/src/pages/Promotions/Details/EligibleShippingMethods.tsx
+++ b/src/pages/Promotions/Details/EligibleShippingMethods.tsx
@@ -11,17 +11,19 @@ import { useShop } from "@containers/ShopProvider";
 import { client } from "@graphql/graphql-request-client";
 import { usePermission } from "@components/PermissionGuard";
 import { filterNodes } from "@utils/common";
-import { AutocompleteField, isOptionEqualToValue } from "@components/AutocompleteField";
+import { AutocompleteField } from "@components/AutocompleteField";
 import { InputWithLabel } from "@components/TextField";
 import { FieldArrayRenderer } from "@components/FieldArrayRenderer";
 
 
 type EligibleShippingMethodsProps = {
   inclusionFieldName: string
+  disabled: boolean
 }
 
-export const EligibleShippingMethods = ({ inclusionFieldName }: EligibleShippingMethodsProps) => {
+export const EligibleShippingMethods = ({ inclusionFieldName, disabled }: EligibleShippingMethodsProps) => {
   const { shopId } = useShop();
+
   const canReadShippingMethods = usePermission(["reaction:legacy:shippingMethods/read"]);
 
   const { data, isLoading } = useGetShippingMethodsQuery(
@@ -30,10 +32,9 @@ export const EligibleShippingMethods = ({ inclusionFieldName }: EligibleShipping
     {
       enabled: !!shopId && canReadShippingMethods,
       select: (response) =>
-        filterNodes(response.flatRateFulfillmentMethods.nodes).map(({ _id, name }) => ({ label: name, value: _id }))
+        filterNodes(response.flatRateFulfillmentMethods.nodes).map(({ name }) => name)
     }
   );
-
   const shippingMethodFieldName = `${inclusionFieldName}[0].value`;
 
   return (
@@ -53,8 +54,8 @@ export const EligibleShippingMethods = ({ inclusionFieldName }: EligibleShipping
 
             <FieldArrayRenderer
               {...props}
-              addButtonProps={{ children: "Add Shipping Method", sx: { ml: 5.7 }, hidden: get(props.form.values, inclusionFieldName, []).length > 0 }}
-              initialValue={{ fact: "item", path: "", value: [], operator: "" }}
+              addButtonProps={{ disabled, children: "Add Shipping Method", sx: { ml: 5.7 }, hidden: get(props.form.values, inclusionFieldName, []).length > 0 }}
+              initialValue={{ fact: "shipping", path: "$.shippingMethod.name", value: [], operator: "in" }}
               renderFieldItem={() => (
                 <Stack pl={5.7}>
                   <Field
@@ -63,7 +64,7 @@ export const EligibleShippingMethods = ({ inclusionFieldName }: EligibleShipping
                     component={AutocompleteField}
                     options={data || []}
                     loading={isLoading}
-                    isOptionEqualToValue={isOptionEqualToValue}
+                    disabled={disabled}
                     renderInput={(params: AutocompleteRenderInputParams) => (
                       <InputWithLabel
                         {...params}

--- a/src/pages/Promotions/Details/PromotionActions.tsx
+++ b/src/pages/Promotions/Details/PromotionActions.tsx
@@ -25,7 +25,10 @@ const getSymbolBasedOnType = (action: Action) => {
   return calculationType ? CALCULATION_TYPE_OPTIONS[calculationType].symbol : null;
 };
 
-export const PromotionActions = () => {
+type PromotionActionsProps = {
+  disabled: boolean
+}
+export const PromotionActions = ({ disabled }: PromotionActionsProps) => {
   const [activeField, setActiveField] = useState<number>();
   const handleClose = () => setActiveField(undefined);
   const { values: { promotionType } } = useFormikContext<Promotion>();
@@ -82,6 +85,7 @@ export const PromotionActions = () => {
 
                 {isShippingDiscount ?
                   <EligibleShippingMethods
+                    disabled={disabled}
                     inclusionFieldName={
                       `actions[${index}].actionParameters.inclusionRules.conditions.all`
                     }

--- a/src/pages/Promotions/Details/PromotionUsageLimits.tsx
+++ b/src/pages/Promotions/Details/PromotionUsageLimits.tsx
@@ -8,7 +8,7 @@ type PromotionUsageLimitsProps = {
 }
 
 export const PromotionUsageLimits = ({ actionParametersFieldName }: PromotionUsageLimitsProps) => (
-  <Stack sx={{ width: { lg: "50%", md: "100%" }, flexDirection: { lg: "row", md: "column" }, gap: { lg: 2, md: 0 } }} alignItems="center">
+  <Stack sx={{ width: { lg: "50%", md: "100%" }, flexDirection: { lg: "row", md: "column" }, gap: { lg: 2, md: 0 }, alignItems: { lg: "flex-start" } }}>
     <Field name={`${actionParametersFieldName}.discountMaxUnits`} component={TextField} type="number" label="Max # uses per Order" />
     <Field name={`${actionParametersFieldName}.discountMaxValue`} component={TextField} type="number" label="Max $ discount on an Order" />
   </Stack>

--- a/src/pages/Promotions/Details/index.tsx
+++ b/src/pages/Promotions/Details/index.tsx
@@ -152,7 +152,7 @@ const PromotionDetails = () => {
   };
 
   const showActionButtons = promotionId ? canUpdate : canCreate;
-  const shouldDisableField = data?.promotion.enabled && data?.promotion.state === PromotionState.Active;
+  const shouldDisableField = Boolean(data?.promotion.enabled && data?.promotion.state === PromotionState.Active);
 
 
   if (isLoading) return <Loader/>;
@@ -218,7 +218,7 @@ const PromotionDetails = () => {
               <Field name="description" component={TextField} multiline label="Promotion Notes" minRows={3}/>
             </Card>
             <Card title="Promotion Builder" divider>
-              <PromotionActions/>
+              <PromotionActions disabled={shouldDisableField}/>
               <PromotionTriggers />
             </Card>
             <Card title="Promotion Stackability" divider>

--- a/src/pages/Promotions/Details/utils.ts
+++ b/src/pages/Promotions/Details/utils.ts
@@ -26,6 +26,8 @@ export const normalizeActionsData = (actions?: Action[]) => actions?.map((action
   ...action,
   actionParameters: {
     ...action.actionParameters,
+    discountMaxUnits: action.actionParameters?.discountMaxUnits || undefined,
+    discountMaxValue: action.actionParameters?.discountMaxValue || undefined,
     inclusionRules: normalizeRule(action.actionParameters?.inclusionRules),
     exclusionRules: normalizeRule(action.actionParameters?.exclusionRules)
   }

--- a/src/pages/Settings/UsersAndPermissions/Users/Users.test.tsx
+++ b/src/pages/Settings/UsersAndPermissions/Users/Users.test.tsx
@@ -11,7 +11,7 @@ describe("Users", () => {
   it("should render Users table", async () => {
     renderWithProviders(<Users/>);
     await screen.findByText("Users");
-    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"), { timeout: 3000 });
 
     users.forEach((user) => {
       expect(screen.getByText(user.name ?? "--")).toBeInTheDocument();
@@ -23,7 +23,7 @@ describe("Users", () => {
   it("should successfully invite new user", async () => {
     renderWithProviders(<Users/>);
     await screen.findByText("Users");
-    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"), { timeout: 3000 });
 
     fireEvent.click(screen.getByText("Invite"));
     expect(screen.getByText("Invite User")).toBeInTheDocument();
@@ -55,7 +55,7 @@ describe("Users", () => {
   it("should successfully update user group", async () => {
     renderWithProviders(<Users/>);
     await screen.findByText("Users");
-    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"), { timeout: 3000 });
 
     fireEvent.click(screen.getByText(users[0].name));
     expect(screen.getByText("Edit User")).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe("Users", () => {
   it("should successfully send reset password email", async () => {
     renderWithProviders(<Users/>);
     await screen.findByText("Users");
-    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"), { timeout: 3000 });
 
     fireEvent.click(screen.getAllByLabelText("more")[0]);
     expect(screen.getByText("Send Password Reset")).toBeInTheDocument();


### PR DESCRIPTION
Resolves #177, #179

Testing Instructions:
- Use branch `feat/shipping-discounts` on API
- Start the app and login with a valid account
- Navigate to Promotions
- Click Actions -> Create New
- Select `Shipping Discount` as Promotion Type
<img width="765" alt="image" src="https://user-images.githubusercontent.com/33818318/220121018-671a4587-b751-4612-b676-2448de1a4890.png">

 - Click Add Action and provide the required fields
 
 - Click Add Shipping Method
 
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/33818318/220121222-75688f00-eb7d-4a75-a57e-312340749ab5.png">

 - Select shipping methods to apply the promotion to

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/33818318/220121354-8d46e53f-440c-42b3-b15d-e53b602dd2da.png">

